### PR TITLE
Addition of getOldPhase to MagicBlockPhaseEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.4.0</build.version>
+        <build.version>1.4.1</build.version>
     </properties>
 
     <!-- Profiles will allow to automatically change build version. -->

--- a/src/main/java/world/bentobox/aoneblock/events/MagicBlockPhaseEvent.java
+++ b/src/main/java/world/bentobox/aoneblock/events/MagicBlockPhaseEvent.java
@@ -15,6 +15,7 @@ import world.bentobox.bentobox.database.objects.Island;
 public class MagicBlockPhaseEvent extends AbstractMagicBlockEvent {
 
     protected final String phase;
+    protected final String oldPhase;
     protected final int blockNumber;
     /**
      * @param island
@@ -23,13 +24,14 @@ public class MagicBlockPhaseEvent extends AbstractMagicBlockEvent {
      * @param phase
      * @param blockNumber
      */
-    public MagicBlockPhaseEvent(Island island, UUID playerUUID, Block block, String phase, int blockNumber) {
+    public MagicBlockPhaseEvent(Island island, UUID playerUUID, Block block, String phase, String oldPhase, int blockNumber) {
         super(island, playerUUID, block);
         this.phase = phase;
+        this.oldPhase = oldPhase;
         this.blockNumber = blockNumber;
     }
     /**
-     * @return the phase
+     * @return the new phase
      */
     @NonNull
     public String getPhase() {
@@ -41,5 +43,10 @@ public class MagicBlockPhaseEvent extends AbstractMagicBlockEvent {
     public int getBlockNumber() {
         return blockNumber;
     }
-
+    /**
+     * @return the original phase
+     */
+    public String getOldPhase() {
+        return oldPhase;
+    }
 }

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -216,6 +216,8 @@ public class BlockListener implements Listener {
         OneBlockIslands is = getIsland(i);
         // Get the phase for this island
         OneBlockPhase phase = oneBlocksManager.getPhase(is.getBlockNumber());
+        // Store the original phase in case it changes.
+        String originalPhase = is.getPhaseName();
         // Check for a goto
         if (phase.getGotoBlock() != null) {
             int gotoBlock = phase.getGotoBlock();
@@ -263,7 +265,7 @@ public class BlockListener implements Listener {
                 }
             }
             // Fire new phase event
-            Bukkit.getPluginManager().callEvent(new MagicBlockPhaseEvent(i, player.getUniqueId(), block, phase.getPhaseName(), is.getBlockNumber()));
+            Bukkit.getPluginManager().callEvent(new MagicBlockPhaseEvent(i, player.getUniqueId(), block, phase.getPhaseName(), originalPhase, is.getBlockNumber()));
         }
         // Entity
         if (nextBlock.isEntity()) {


### PR DESCRIPTION
After creating a Prestige addon for AOneBlock, it became apparent that you couldn't fetch the Old Phase (for comparison) through the API, as by the time the event is called, it has already been modified. 

I've simply stored this, and created a getter for manipulation, whilst trying to maintain your current codestyle. 