### PR TITLE
Add Hologram Support to AOneBlock Phases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,8 @@
             <groupId>com.gmail.filoghost.holographicdisplays</groupId>
             <artifactId>holographicdisplays-api</artifactId>
             <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Mojang Auth-->
         <dependency>
             <groupId>com.mojang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,13 @@
             <version>${spigot.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- Holographic Displays API -->
+        <dependency>
+            <groupId>com.gmail.filoghost.holographicdisplays</groupId>
+            <artifactId>holographicdisplays-api</artifactId>
+            <version>2.4.0</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Mockito (Unit testing) -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -3,6 +3,7 @@ package world.bentobox.aoneblock;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.WorldCreator;
@@ -43,6 +44,7 @@ public class AOneBlock extends GameModeAddon {
     private BlockListener blockListener;
     private OneBlocksManager oneBlockManager;
     private PlaceholdersManager phManager;
+    private Boolean useHolographicDisplays;
 
     @Override
     public void onLoad() {
@@ -55,6 +57,8 @@ public class AOneBlock extends GameModeAddon {
         // Register commands
         playerCommand = new PlayerCommand(this);
         adminCommand = new AdminCommand(this);
+        // Decide if HolographicDisplays is Useable
+        useHolographicDisplays = Bukkit.getPluginManager().isPluginEnabled("HolographicDisplays");
     }
 
     private boolean loadSettings() {

--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -117,27 +117,7 @@ public class AOneBlock extends GameModeAddon {
 
         // Decide if HolographicDisplays is Useable
         useHolographicDisplays = Bukkit.getPluginManager().isPluginEnabled("HolographicDisplays");
-
-        // Replace Missing Holograms
-        Bukkit.getScheduler().runTaskLater(BentoBox.getInstance(), new Runnable() {
-            @Override
-            public void run() {
-                if (useHolographicDisplays()) {
-                    for (Island island : getIslands().getIslands()) {
-                        OneBlockIslands oneBlockIsland = getOneBlocksIsland(island);
-                        String hololine = oneBlockIsland.getHologram();
-                        if (hololine != null) {
-                            final Hologram hologram = HologramsAPI.createHologram(BentoBox.getInstance(), island.getCenter().add(0.5, 2.6, 0.5));
-                            for (String line : hololine.split("\\n")) {
-                                hologram.appendTextLine(ChatColor.translateAlternateColorCodes('&', line));
-                            }
-                        }
-                    }
-                }
-            }
-        }, 400L); // Wait 20 Seconds so that all Islands are Loaded
     }
-
 
     @Override
     public void onDisable() {
@@ -254,6 +234,20 @@ public class AOneBlock extends GameModeAddon {
     public void allLoaded() {
         // save settings. This will occur after all addons have loaded
         this.saveWorldSettings();
+
+        // Manage Old Holograms
+        if (useHolographicDisplays()) {
+            for (Island island : getIslands().getIslands()) {
+                OneBlockIslands oneBlockIsland = getOneBlocksIsland(island);
+                String hololine = oneBlockIsland.getHologram();
+                if (hololine != null) {
+                    final Hologram hologram = HologramsAPI.createHologram(BentoBox.getInstance(), island.getCenter().add(0.5, 2.6, 0.5));
+                    for (String line : hololine.split("\\n")) {
+                        hologram.appendTextLine(ChatColor.translateAlternateColorCodes('&', line));
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
+++ b/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
@@ -28,6 +28,8 @@ public class OneBlockIslands implements DataObject {
     private long lifetime;
     @Expose
     private String phaseName = "";
+    @Expose
+    private String hologram = "";
 
     private List<OneBlockObject> queue = new ArrayList<>();
 
@@ -69,6 +71,20 @@ public class OneBlockIslands implements DataObject {
      */
     public void incrementBlockNumber() {
         this.blockNumber++;
+    }
+
+    /**
+     * @return the hologram Line
+     */
+    public String getHologram() {
+        return hologram;
+    }
+
+    /**
+     * @param hologramLine
+     */
+    public void setHologram(String hologramLine) {
+        this.hologram = hologramLine;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -1,24 +1,8 @@
 package world.bentobox.aoneblock.listeners;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
-import org.bukkit.Tag;
-import org.bukkit.World;
+import com.gmail.filoghost.holographicdisplays.api.Hologram;
+import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
+import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -43,18 +27,14 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
-
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.events.MagicBlockEntityEvent;
 import world.bentobox.aoneblock.events.MagicBlockEvent;
 import world.bentobox.aoneblock.events.MagicBlockPhaseEvent;
-import world.bentobox.aoneblock.oneblocks.MobAspects;
-import world.bentobox.aoneblock.oneblocks.OneBlockObject;
-import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
-import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
-import world.bentobox.aoneblock.oneblocks.Requirement;
+import world.bentobox.aoneblock.oneblocks.*;
 import world.bentobox.bank.Bank;
+import world.bentobox.bentobox.BentoBox;
 import world.bentobox.bentobox.api.events.island.IslandCreatedEvent;
 import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
 import world.bentobox.bentobox.api.events.island.IslandResettedEvent;
@@ -65,9 +45,12 @@ import world.bentobox.bentobox.database.objects.Island;
 import world.bentobox.bentobox.util.Util;
 import world.bentobox.level.Level;
 
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
 /**
  * @author tastybento
- *
  */
 public class BlockListener implements Listener {
 
@@ -81,6 +64,7 @@ public class BlockListener implements Listener {
      * Tools that take damage. See https://minecraft.gamepedia.com/Item_durability#Tool_durability
      */
     private static final Map<Material, Integer> TOOLS;
+
     static {
         Map<Material, Integer> t = new EnumMap<>(Material.class);
         t.put(Material.DIAMOND_AXE, 1);
@@ -107,6 +91,7 @@ public class BlockListener implements Listener {
         t.put(Material.TRIDENT, 2);
         TOOLS = Collections.unmodifiableMap(t);
     }
+
     /**
      * Water entities
      */
@@ -126,6 +111,7 @@ public class BlockListener implements Listener {
     private static final Map<EntityType, MobAspects> MOB_ASPECTS;
     public static final int MAX_LOOK_AHEAD = 5;
     public static final int SAVE_EVERY = 50;
+
     static {
         Map<EntityType, MobAspects> m = new EnumMap<>(EntityType.class);
         m.put(EntityType.BLAZE, new MobAspects(Sound.ENTITY_BLAZE_AMBIENT, Color.fromRGB(238, 211, 91)));
@@ -221,6 +207,7 @@ public class BlockListener implements Listener {
 
     /**
      * Handles JetsMinions. These are special armor stands. Requires Minions 6.9.3 or later
+     *
      * @param e - event
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -234,6 +221,7 @@ public class BlockListener implements Listener {
 
     /**
      * Check for water grabbing
+     *
      * @param e - event (note that you cannot register PlayerBucketEvent)
      */
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -246,10 +234,11 @@ public class BlockListener implements Listener {
 
     /**
      * Main block processing method
-     * @param e - event causing the processing
-     * @param i - island where it's happening
+     *
+     * @param e      - event causing the processing
+     * @param i      - island where it's happening
      * @param player - player who broke the block or who is involved - may be null
-     * @param world - world where the block is being broken
+     * @param world  - world where the block is being broken
      */
     private void process(@NonNull Cancellable e, @NonNull Island i, @Nullable Player player, @NonNull World world) {
         // Get island from cache or load it
@@ -283,7 +272,7 @@ public class BlockListener implements Listener {
             is.clearQueue();
         }
         // Get the block number in this phase
-        int blockNumber = is.getBlockNumber() - phase.getBlockNumberValue() + (int)is.getQueue().stream().filter(OneBlockObject::isMaterial).count();
+        int blockNumber = is.getBlockNumber() - phase.getBlockNumberValue() + (int) is.getQueue().stream().filter(OneBlockObject::isMaterial).count();
         // Get the block that is being broken
         Block block = Objects.requireNonNull(i.getCenter()).toVector().toLocation(world).getBlock();
         // Fill a 5 block queue
@@ -291,6 +280,18 @@ public class BlockListener implements Listener {
             // Add initial 5 blocks
             for (int j = 0; j < MAX_LOOK_AHEAD; j++) {
                 is.add(phase.getNextBlock(addon, blockNumber++));
+            }
+        }
+        // Manage Holograms
+        for (Hologram hologram : HologramsAPI.getHolograms(BentoBox.getInstance())) {
+            if (!addon.inWorld(hologram.getWorld())) continue;
+            addon.getIslands().getIslandAt(hologram.getLocation()).ifPresent(h -> hologram.delete());
+        }
+        String hololine = phase.getHologramLine(is.getBlockNumber());
+        if (hololine != null) {
+            final Hologram hologram = HologramsAPI.createHologram(BentoBox.getInstance(), i.getCenter().add(0.5, 2.1, 0.5));
+            for (String line : hololine.split("\\n")) {
+                hologram.appendTextLine(ChatColor.translateAlternateColorCodes('&', line));
             }
         }
         // Play warning sound for upcoming mobs
@@ -318,12 +319,12 @@ public class BlockListener implements Listener {
         if (e instanceof BlockBreakEvent) {
             breakBlock(e, player, block, world, nextBlock, i);
         } else if (e instanceof PlayerBucketFillEvent) {
-            Bukkit.getScheduler().runTask(addon.getPlugin(), ()-> spawnBlock(nextBlock, block));
+            Bukkit.getScheduler().runTask(addon.getPlugin(), () -> spawnBlock(nextBlock, block));
             // Fire event
             ItemStack tool = Objects.requireNonNull(player).getInventory().getItemInMainHand();
             Bukkit.getPluginManager().callEvent(new MagicBlockEvent(i, player.getUniqueId(), tool, block, nextBlock.getMaterial()));
         } else if (e instanceof EntitySpawnEvent) {
-            Bukkit.getScheduler().runTask(addon.getPlugin(), ()-> spawnBlock(nextBlock, block));
+            Bukkit.getScheduler().runTask(addon.getPlugin(), () -> spawnBlock(nextBlock, block));
         } else if (e instanceof EntityInteractEvent) {
             // Minion breaking block
             Bukkit.getScheduler().runTask(addon.getPlugin(), () -> spawnBlock(nextBlock, block));
@@ -336,10 +337,11 @@ public class BlockListener implements Listener {
 
     /**
      * Checks whether the player can proceed to the next phase
+     *
      * @param player - player
-     * @param i - island
-     * @param phase - one block phase
-     * @param world - world
+     * @param i      - island
+     * @param phase  - one block phase
+     * @param world  - world
      * @return true if the player can proceed to the next phase, false if not or if there is no next phase.
      */
     private boolean phaseRequirementsFail(@Nullable Player player, @NonNull Island i, OneBlockPhase phase, @NonNull World world) {
@@ -349,38 +351,38 @@ public class BlockListener implements Listener {
         // Check requirements
         for (Requirement r : phase.getRequirements()) {
             switch (r.getType()) {
-            case LEVEL:
-                return addon.getAddonByName("Level").map(l -> {
-                    if (((Level)l).getIslandLevel(world, i.getOwner()) < r.getLevel()) {
-                        User.getInstance(player).sendMessage("aoneblock.phase.insufficient-level", TextVariables.NUMBER, String.valueOf(r.getLevel()));
+                case LEVEL:
+                    return addon.getAddonByName("Level").map(l -> {
+                        if (((Level) l).getIslandLevel(world, i.getOwner()) < r.getLevel()) {
+                            User.getInstance(player).sendMessage("aoneblock.phase.insufficient-level", TextVariables.NUMBER, String.valueOf(r.getLevel()));
+                            return true;
+                        }
+                        return false;
+                    }).orElse(false);
+                case BANK:
+                    return addon.getAddonByName("Bank").map(l -> {
+                        if (((Bank) l).getBankManager().getBalance(i).getValue() < r.getBank()) {
+                            User.getInstance(player).sendMessage("aoneblock.phase.insufficient-bank-balance", TextVariables.NUMBER, String.valueOf(r.getBank()));
+                            return true;
+                        }
+                        return false;
+                    }).orElse(false);
+                case ECO:
+                    return addon.getPlugin().getVault().map(l -> {
+                        if (l.getBalance(User.getInstance(player), world) < r.getEco()) {
+                            User.getInstance(player).sendMessage("aoneblock.phase.insufficient-funds", TextVariables.NUMBER, String.valueOf(r.getEco()));
+                            return true;
+                        }
+                        return false;
+                    }).orElse(false);
+                case PERMISSION:
+                    if (player != null && !player.hasPermission(r.getPermission())) {
+                        User.getInstance(player).sendMessage("aoneblock.phase.insufficient-permission", TextVariables.NAME, String.valueOf(r.getPermission()));
                         return true;
                     }
                     return false;
-                }).orElse(false);
-            case BANK:
-                return addon.getAddonByName("Bank").map(l -> {
-                    if (((Bank)l).getBankManager().getBalance(i).getValue() < r.getBank()) {
-                        User.getInstance(player).sendMessage("aoneblock.phase.insufficient-bank-balance", TextVariables.NUMBER, String.valueOf(r.getBank()));
-                        return true;
-                    }
-                    return false;
-                }).orElse(false);
-            case ECO:
-                return addon.getPlugin().getVault().map(l -> {
-                    if (l.getBalance(User.getInstance(player), world) < r.getEco()) {
-                        User.getInstance(player).sendMessage("aoneblock.phase.insufficient-funds", TextVariables.NUMBER, String.valueOf(r.getEco()));
-                        return true;
-                    }
-                    return false;
-                }).orElse(false);
-            case PERMISSION:
-                if (player != null && !player.hasPermission(r.getPermission())) {
-                    User.getInstance(player).sendMessage("aoneblock.phase.insufficient-permission", TextVariables.NAME, String.valueOf(r.getPermission()));
-                    return true;
-                }
-                return false;
-            default:
-                break;
+                default:
+                    break;
 
             }
         }
@@ -398,10 +400,11 @@ public class BlockListener implements Listener {
 
     /**
      * Check whether this phase is done or not.
+     *
      * @param player - player
-     * @param i - island
-     * @param is - OneBlockIslands object
-     * @param phase - current phase name
+     * @param i      - island
+     * @param is     - OneBlockIslands object
+     * @param phase  - current phase name
      * @return true if this is a new phase, false if not
      */
     private boolean checkPhase(@Nullable Player player, @NonNull Island i, @NonNull OneBlockIslands is, @NonNull OneBlockPhase phase) {
@@ -409,9 +412,9 @@ public class BlockListener implements Listener {
         if (!is.getPhaseName().equalsIgnoreCase(phaseName)) {
             // Run previous phase end commands
             oneBlocksManager.getPhase(is.getPhaseName()).ifPresent(oldPhase ->
-            Util.runCommands(User.getInstance(player),
-                    replacePlaceholders(player, oldPhase.getPhaseName(), phase.getBlockNumber(), i, oldPhase.getEndCommands()),
-                    "Commands run for end of " + oldPhase.getPhaseName()));
+                    Util.runCommands(User.getInstance(player),
+                            replacePlaceholders(player, oldPhase.getPhaseName(), phase.getBlockNumber(), i, oldPhase.getEndCommands()),
+                            "Commands run for end of " + oldPhase.getPhaseName()));
             // Set the phase name
             is.setPhaseName(phaseName);
             if (player != null) {
@@ -440,19 +443,19 @@ public class BlockListener implements Listener {
      * [eco-balance] - player's economy balance (Requires Vault and an economy plugin)
      * </pre>
      *
-     * @param player - player
-     * @param phaseName - phase name
+     * @param player      - player
+     * @param phaseName   - phase name
      * @param phaseNumber - phase's block number
-     * @param i - island
-     * @param commands - list of commands
+     * @param i           - island
+     * @param commands    - list of commands
      * @return list of commands with placeholders replaced
      */
     @NonNull
     List<String> replacePlaceholders(@Nullable Player player, @NonNull String phaseName, @NonNull String phaseNumber, @NonNull Island i, List<String> commands) {
         return commands.stream()
                 .map(c -> {
-                    long level = addon.getAddonByName("Level").map(l -> ((Level)l).getIslandLevel(addon.getOverWorld(), i.getOwner())).orElse(0L);
-                    double balance = addon.getAddonByName("Bank").map(b -> ((Bank)b).getBankManager().getBalance(i).getValue()).orElse(0D);
+                    long level = addon.getAddonByName("Level").map(l -> ((Level) l).getIslandLevel(addon.getOverWorld(), i.getOwner())).orElse(0L);
+                    double balance = addon.getAddonByName("Bank").map(b -> ((Bank) b).getBankManager().getBalance(i).getValue()).orElse(0D);
                     double ecoBalance = addon.getPlugin().getVault().map(v -> v.getBalance(User.getInstance(player), addon.getOverWorld())).orElse(0D);
 
                     return c.replace("[island]", i.getName() == null ? "" : i.getName())
@@ -505,18 +508,18 @@ public class BlockListener implements Listener {
         if (addon.getSettings().isDropOnTop()) {
             // Drop the drops
             block.getDrops(tool, player).stream()
-            .filter(Objects::nonNull)
-            .filter(item -> !item.getType().equals(Material.AIR))
-            .forEach(item -> world.dropItem(block.getRelative(BlockFace.UP).getLocation()
-                    .add(new Vector(0.5, 0, 0.5)), item)
-                    .setVelocity(new Vector(0,0,0)));
+                    .filter(Objects::nonNull)
+                    .filter(item -> !item.getType().equals(Material.AIR))
+                    .forEach(item -> world.dropItem(block.getRelative(BlockFace.UP).getLocation()
+                            .add(new Vector(0.5, 0, 0.5)), item)
+                            .setVelocity(new Vector(0, 0, 0)));
             // Set the air
             block.setType(Material.AIR);
         } else {
             block.breakNaturally(tool);
         }
         // Give exp
-        Objects.requireNonNull(player).giveExp(((BlockBreakEvent)e).getExpToDrop());
+        Objects.requireNonNull(player).giveExp(((BlockBreakEvent) e).getExpToDrop());
         // Damage tool
         damageTool(Objects.requireNonNull(player));
         spawnBlock(nextBlock, block);
@@ -533,7 +536,7 @@ public class BlockListener implements Listener {
             return;
         }
         if (Tag.LEAVES.isTagged(type)) {
-            Leaves leaves = (Leaves)block.getState().getBlockData();
+            Leaves leaves = (Leaves) block.getState().getBlockData();
             leaves.setPersistent(true);
             block.setBlockData(leaves);
         }
@@ -555,9 +558,9 @@ public class BlockListener implements Listener {
         for (double x = bb.getMinX(); x <= bb.getMaxX() + 1; x++) {
             for (double z = bb.getMinZ(); z <= bb.getMaxZ() + 1; z++) {
                 double y = bb.getMinY();
-                Block b = world.getBlockAt(new Location(world, x,y,z));
+                Block b = world.getBlockAt(new Location(world, x, y, z));
                 for (; y <= Math.min(bb.getMaxY() + 1, world.getMaxHeight()); y++) {
-                    b = world.getBlockAt(new Location(world, x,y,z));
+                    b = world.getBlockAt(new Location(world, x, y, z));
                     if (!b.getType().equals(Material.AIR) && !b.isLiquid()) b.breakNaturally();
                     b.setType(WATER_ENTITIES.contains(e.getType()) && addon.getSettings().isWaterMobProtection() ? Material.WATER : Material.AIR, false);
                 }
@@ -570,28 +573,29 @@ public class BlockListener implements Listener {
     }
 
     private void fillChest(@NonNull OneBlockObject nextBlock, @NonNull Block block) {
-        Chest chest = (Chest)block.getState();
+        Chest chest = (Chest) block.getState();
         nextBlock.getChest().forEach(chest.getBlockInventory()::setItem);
-        Color color = Color.fromBGR(0,255,255); // yellow
+        Color color = Color.fromBGR(0, 255, 255); // yellow
         switch (nextBlock.getRarity()) {
-        case EPIC:
-            color = Color.fromBGR(255,0,255); // magenta
-            break;
-        case RARE:
-            color = Color.fromBGR(255,255,255); // cyan
-            break;
-        case UNCOMMON:
-            // Yellow
-            break;
-        default:
-            // No sparkles for regular chests
-            return;
+            case EPIC:
+                color = Color.fromBGR(255, 0, 255); // magenta
+                break;
+            case RARE:
+                color = Color.fromBGR(255, 255, 255); // cyan
+                break;
+            case UNCOMMON:
+                // Yellow
+                break;
+            default:
+                // No sparkles for regular chests
+                return;
         }
         block.getWorld().spawnParticle(Particle.REDSTONE, block.getLocation().add(new Vector(0.5, 1.0, 0.5)), 50, 0.5, 0, 0.5, 1, new Particle.DustOptions(color, 1));
     }
 
     /**
      * Get the one block island data
+     *
      * @param i - island
      * @return one block island
      */
@@ -653,6 +657,7 @@ public class BlockListener implements Listener {
 
     /**
      * Saves the island progress to the database async
+     *
      * @param island - island
      * @return CompletableFuture - true if saved or not in cache, false if save failed
      */

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -404,3 +404,4 @@ public class OneBlockPhase {
     public void setHologramLines(Map<Integer, String> hologramLines) {
         this.holograms = hologramLines;
     }
+}

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -52,6 +52,7 @@ public class OneBlockPhase {
     private List<String> endCommands;
     private List<Requirement> requirements;
     private Map<Integer, OneBlockObject> fixedBlocks;
+    private Map<Integer, String> holograms;
 
 
     /**
@@ -65,6 +66,7 @@ public class OneBlockPhase {
         endCommands = new ArrayList<>();
         requirements = new ArrayList<>();
         fixedBlocks = new HashMap<>();
+        holograms = new HashMap<>();
     }
 
     /**
@@ -80,6 +82,21 @@ public class OneBlockPhase {
      */
     public int getBlockNumberValue() {
         return Integer.parseInt(blockNumber);
+    }
+
+    /**
+     * @return the hologramLine
+     */
+    @Nullable
+    public String getHologramLine(Integer block) {
+        return holograms.getOrDefault(block, null);
+    }
+
+    /**
+     * @return the hologramLines
+     */
+    public Map<Integer, String> getHologramLines() {
+        return holograms;
     }
 
     /**
@@ -349,5 +366,11 @@ public class OneBlockPhase {
         this.fixedBlocks = fixedBlocks;
     }
 
+    /**
+     * @param hologramLines the hologramLines to set
+     */
+    public void setHologramLines(Map<Integer, String> hologramLines) {
+        this.holograms = hologramLines;
+    }
 
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -44,6 +44,7 @@ public class OneBlocksManager {
     private static final String BIOME = "biome";
     private static final String FIRST_BLOCK = "firstBlock";
     private static final String FIXED_BLOCKS = "fixedBlocks";
+    private static final String HOLOGRAMS = "holograms";
     private static final String CHESTS = "chests";
     private static final String RARITY = "rarity";
     private static final String CONTENTS = "contents";
@@ -181,6 +182,13 @@ public class OneBlocksManager {
             }
             addFixedBlocks(obPhase, phase.getConfigurationSection(FIXED_BLOCKS));
         }
+
+        if (phase.contains(HOLOGRAMS)) {
+            if (!obPhase.getHologramLines().isEmpty()) {
+                throw new IOException("Block " + blockNumber + ": Hologram Lines trying to be set to " + phase.getString(HOLOGRAMS) + " but already set to " + obPhase.getHologramLines() + " Duplicate phase file?");
+            }
+            addHologramLines(obPhase, phase.getConfigurationSection(HOLOGRAMS));
+        }
     }
 
     private void addFixedBlocks(OneBlockPhase obPhase, ConfigurationSection fb) {
@@ -208,6 +216,25 @@ public class OneBlocksManager {
         }
         // Store the remainder
         obPhase.setFixedBlocks(result);
+
+    }
+
+    private void addHologramLines(OneBlockPhase obPhase, ConfigurationSection fb) {
+        if (fb == null) return;
+        Map<Integer, String> result = new HashMap<>();
+        for (String key : fb.getKeys(false)) {
+            if (!NumberUtils.isNumber(key)) {
+                addon.logError("Fixed block key must be an integer. " + key);
+                continue;
+            }
+            int k = Integer.parseInt(key);
+            String line = fb.getString(key);
+            if (line != null) {
+                    result.put(k, line);
+            }
+        }
+        // Set Hologram Lines
+        obPhase.setHologramLines(result);
 
     }
 

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -39,4 +39,5 @@ aoneblock:
     insufficient-permission: "&c You can proceed no futher until you obtain the [name] permission!"
   placeholders:
     infinite: Infinite
-    
+  island:
+    starting-hologram: "&aWelcome to AOneBlock\n&eBreak This Block to Begin"

--- a/src/main/resources/phases/0_plains.yml
+++ b/src/main/resources/phases/0_plains.yml
@@ -11,9 +11,10 @@
     4: OAK_LOG
     5: OAK_LOG
     50: SPONGE
+  # Hologram Lines to Display
+  # The First (Before Phase 1) Hologram is Located in your Locale.
   holograms:
-    0: "&aWelcome To AOneBlock\n&eBreak This Block To Begin"
-    1: "&aGood Luck!"
+    0: "&aGood Luck!"
   biome: PLAINS
   # Commands
   # A list of commands can be run at the start and end of a phase. Commands are run as the Console

--- a/src/main/resources/phases/0_plains.yml
+++ b/src/main/resources/phases/0_plains.yml
@@ -11,6 +11,9 @@
     4: OAK_LOG
     5: OAK_LOG
     50: SPONGE
+  holograms:
+    0: "&aWelcome To AOneBlock\n&eBreak This Block To Begin"
+    1: "&aGood Luck!"
   biome: PLAINS
   # Commands
   # A list of commands can be run at the start and end of a phase. Commands are run as the Console


### PR DESCRIPTION
This Commit Adds Hologram Support (via HolographicDisplays) to Phases in the same way FixedBlocks work.
```yaml
  holograms:
    0: "&aGood Luck!"
    1: "&aAnd Have Fun!"
```

This requires BentoBoxWorld/BentoBox#1794 for HolographicDisplays.

The other thing I will note is that due to the *first* block placed when the gamemode starts not being in any phase (Break 1 block to unlock plains) I've had to add the Starting hologram to the Locale file. It doesn't make very much sense, but thats the only good way I've found. I'm open to other suggestions though :)

```yaml
aoneblock:
  island:
    starting-hologram: "&aWelcome to AOneBlock\n&eBreak This Block to Begin"
```