### PR TITLE
cache as ConcurrentHashMap

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -47,6 +47,7 @@ import world.bentobox.level.Level;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -154,7 +155,7 @@ public class BlockListener implements Listener {
     public BlockListener(@NonNull AOneBlock addon) {
         this.addon = addon;
         handler = new Database<>(addon, OneBlockIslands.class);
-        cache = new HashMap<>();
+        cache = new ConcurrentHashMap<>();
         oneBlocksManager = addon.getOneBlockManager();
     }
 


### PR DESCRIPTION
Sometimes I get this CME when loading Islands, so this PR may help
```
[20:21:36] [Craft Scheduler Thread - 22 - BetterBoard/WARN]: [BetterBoard] Plugin BetterBoard v1.0-SNAPSHOT generated an exception while executing task 104
java.util.ConcurrentModificationException: null
	at java.util.HashMap.computeIfAbsent(HashMap.java:1225) ~[?:?]
	at world.bentobox.aoneblock.listeners.BlockListener.loadIsland(BlockListener.java:681) ~[?:?]
	at world.bentobox.aoneblock.listeners.BlockListener.getIsland(BlockListener.java:637) ~[?:?]
	at world.bentobox.aoneblock.AOneBlock.getOneBlocksIsland(AOneBlock.java:260) ~[?:?]
	at world.bentobox.aoneblock.PlaceholdersManager.getPhase(PlaceholdersManager.java:68) ~[?:?]
	at world.bentobox.bentobox.api.placeholders.placeholderapi.BasicPlaceholderExpansion.onPlaceholderRequest(BasicPlaceholderExpansion.java:47) ~[BentoBox.jar:?]
	at world.bentobox.bentobox.api.placeholders.placeholderapi.AddonPlaceholderExpansion.onPlaceholderRequest(AddonPlaceholderExpansion.java:5) ~[BentoBox.jar:?]
	at me.clip.placeholderapi.PlaceholderHook.onRequest(PlaceholderHook.java:31) ~[PlaceholderAPI.jar:?]
	at me.clip.placeholderapi.replacer.CharsReplacer.apply(CharsReplacer.java:160) ~[PlaceholderAPI.jar:?]
	at me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(PlaceholderAPI.java:70) ~[PlaceholderAPI.jar:?]
	at me.hsgamer.betterboard.hook.PlaceholderAPIHook.setPlaceholders(PlaceholderAPIHook.java:25) ~[BetterBoard.jar:?]
	at me.hsgamer.betterboard.BetterBoard$1.replace(BetterBoard.java:41) ~[BetterBoard.jar:?]
	at me.hsgamer.betterboard.lib.core.variable.VariableManager.setSingleVariables(VariableManager.java:166) ~[BetterBoard.jar:?]
	at me.hsgamer.betterboard.lib.core.variable.VariableManager.setVariables(VariableManager.java:131) ~[BetterBoard.jar:?]
	at me.hsgamer.betterboard.provider.SimpleBoardProvider.lambda$fetch$1(SimpleBoardProvider.java:38) ~[BetterBoard.jar:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at me.hsgamer.betterboard.provider.SimpleBoardProvider.fetch(SimpleBoardProvider.java:40) ~[BetterBoard.jar:?]
	at me.hsgamer.betterboard.board.Board.lambda$run$0(Board.java:42) ~[BetterBoard.jar:?]
	at java.util.Optional.flatMap(Optional.java:289) ~[?:?]
	at me.hsgamer.betterboard.board.Board.run(Board.java:42) ~[BetterBoard.jar:?]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftTask.run(CraftTask.java:101) ~[patched_1.17.1.jar:git-Purpur-1320]
	at org.bukkit.craftbukkit.v1_17_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[patched_1.17.1.jar:git-Purpur-1320]
	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[patched_1.17.1.jar:git-Purpur-1320]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630) ~[?:?]
	at java.lang.Thread.run(Thread.java:831) [?:?]
```