### PR TITLE
Implement user editable Phases Panel.

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -236,6 +236,16 @@ public class AOneBlock extends GameModeAddon {
         }
     }
 
+
+    @Override
+    public void saveDefaultConfig()
+    {
+        super.saveDefaultConfig();
+        // Save default phases panel
+        this.saveResource("panels/phases_panel.yml", false);
+    }
+
+
     /* (non-Javadoc)
      * @see world.bentobox.bentobox.api.addons.Addon#allLoaded()
      */

--- a/src/main/java/world/bentobox/aoneblock/commands/IslandPhasesCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/IslandPhasesCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.panels.PhasesPanel;
 import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.localization.TextVariables;
 import world.bentobox.bentobox.api.panels.PanelItem;
@@ -34,27 +35,7 @@ public class IslandPhasesCommand extends CompositeCommand {
 
     @Override
     public boolean execute(User user, String label, List<String> args) {
-        PanelBuilder pb = new PanelBuilder()
-                .user(user)
-                .name(user.getTranslation("aoneblock.commands.phases.title"));
-        List<PanelItem> items = addon.getOneBlockManager().getBlockProbs().entrySet().stream()
-                .filter(en -> !en.getValue().isGotoPhase())
-                .sorted(Comparator.comparingInt(Map.Entry::getKey))
-                .map(en -> {
-                    PanelItemBuilder item = new PanelItemBuilder();
-                    item.name(user.getTranslation("aoneblock.commands.phases.name-syntax",
-                            TextVariables.NAME, en.getValue().getPhaseName(),
-                            TextVariables.NUMBER, String.valueOf(en.getKey())));
-                    ItemStack firstBlock = en.getValue().getFirstBlock() == null ? new ItemStack(Material.STONE, 1) : new ItemStack(en.getValue().getFirstBlock().getMaterial(), 1);
-                    ItemStack icon = en.getValue().getIconBlock() == null ? firstBlock : en.getValue().getIconBlock();
-                    item.icon(icon);
-                    item.description(user.getTranslation("aoneblock.commands.phases.description-syntax",
-                            TextVariables.NAME, en.getValue().getPhaseName(),
-                            TextVariables.NUMBER, String.valueOf(en.getKey())));
-                    return item.build();
-                }).toList();
-        items.forEach(pb::item);
-        pb.build();
+        PhasesPanel.openPanel(this.addon, this.getWorld(), user);
         return true;
     }
 }

--- a/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
+++ b/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
@@ -1,0 +1,616 @@
+//
+// Created by BONNe
+// Copyright - 2021
+//
+
+package world.bentobox.aoneblock.panels;
+
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
+import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
+import world.bentobox.aoneblock.oneblocks.Requirement;
+import world.bentobox.bank.Bank;
+import world.bentobox.bentobox.api.panels.PanelItem;
+import world.bentobox.bentobox.api.panels.TemplatedPanel;
+import world.bentobox.bentobox.api.panels.builders.PanelItemBuilder;
+import world.bentobox.bentobox.api.panels.builders.TemplatedPanelBuilder;
+import world.bentobox.bentobox.api.panels.reader.ItemTemplateRecord;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.hooks.LangUtilsHook;
+import world.bentobox.level.Level;
+
+
+/**
+ * This class shows how to set up easy panel by using BentoBox PanelBuilder API
+ */
+public class PhasesPanel
+{
+// ---------------------------------------------------------------------
+// Section: Constructor
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This is internal constructor. It is used internally in current class to avoid creating objects everywhere.
+     *
+     * @param addon VisitAddon object
+     * @param world World where user will be teleported
+     * @param user User who opens panel
+     */
+    private PhasesPanel(AOneBlock addon,
+        World world,
+        User user)
+    {
+        this.addon = addon;
+        this.user = user;
+        this.world = world;
+
+        this.elementList = addon.getOneBlockManager().getBlockProbs().entrySet().stream().
+            filter(en -> !en.getValue().isGotoPhase()).
+            sorted(Comparator.comparingInt(Map.Entry::getKey)).
+            collect(Collectors.toList());
+
+        this.island = this.addon.getIslandsManager().getIsland(world, user);
+        this.oneBlockIsland = this.island == null ? null : this.addon.getBlockListener().getIsland(this.island);
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Build method manages current panel opening. It uses BentoBox PanelAPI that is easy to use and users can get nice
+     * panels.
+     */
+    private void build()
+    {
+        // Do not open gui if there is no magic sticks.
+        if (this.elementList.isEmpty())
+        {
+            this.addon.logError("There are no available phases for selection!");
+            this.user.sendMessage("no-phases",
+                "[gamemode]", this.addon.getDescription().getName());
+            return;
+        }
+
+        // Start building panel.
+        TemplatedPanelBuilder panelBuilder = new TemplatedPanelBuilder();
+
+        // Set main template.
+        panelBuilder.template("phases_panel", new File(this.addon.getDataFolder(), "panels"));
+        panelBuilder.user(this.user);
+        panelBuilder.world(this.user.getWorld());
+
+        // Register button builders
+        panelBuilder.registerTypeBuilder("PHASE", this::createPhaseButton);
+
+        // Register next and previous builders
+        panelBuilder.registerTypeBuilder("NEXT", this::createNextButton);
+        panelBuilder.registerTypeBuilder("PREVIOUS", this::createPreviousButton);
+
+        // Register unknown type builder.
+        panelBuilder.build();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Buttons
+// ---------------------------------------------------------------------
+
+
+    /**
+     * Create next button panel item.
+     *
+     * @param template the template
+     * @param slot the slot
+     * @return the panel item
+     */
+    @Nullable
+    private PanelItem createNextButton(@NonNull ItemTemplateRecord template, TemplatedPanel.ItemSlot slot)
+    {
+        int size = this.elementList.size();
+
+        if (size <= slot.amountMap().getOrDefault("PHASE", 1) ||
+            1.0 * size / slot.amountMap().getOrDefault("PHASE", 1) <= this.pageIndex + 1)
+        {
+            // There are no next elements
+            return null;
+        }
+
+        int nextPageIndex = this.pageIndex + 2;
+
+        PanelItemBuilder builder = new PanelItemBuilder();
+
+        if (template.icon() != null)
+        {
+            ItemStack clone = template.icon().clone();
+
+            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            {
+                clone.setAmount(nextPageIndex);
+            }
+
+            builder.icon(clone);
+        }
+
+        if (template.title() != null)
+        {
+            builder.name(this.user.getTranslation(this.world, template.title()));
+        }
+
+        if (template.description() != null)
+        {
+            builder.description(this.user.getTranslation(this.world, template.description(),
+                "[number]", String.valueOf(nextPageIndex)));
+        }
+
+        // Add ClickHandler
+        builder.clickHandler((panel, user, clickType, i) ->
+        {
+            template.actions().forEach(action -> {
+                if (clickType == action.clickType()  || action.clickType() == ClickType.UNKNOWN)
+                {
+                    if ("NEXT".equalsIgnoreCase(action.actionType()))
+                    {
+                        // Next button ignores click type currently.
+                        this.pageIndex++;
+                        this.build();
+                    }
+                }
+            });
+
+            // Always return true.
+            return true;
+        });
+
+        // Collect tooltips.
+        List<String> tooltips = template.actions().stream().
+            filter(action -> action.tooltip() != null).
+            map(action -> this.user.getTranslation(this.world, action.tooltip())).
+            filter(text -> !text.isBlank()).
+            collect(Collectors.toCollection(() -> new ArrayList<>(template.actions().size())));
+
+        // Add tooltips.
+        if (!tooltips.isEmpty())
+        {
+            // Empty line and tooltips.
+            builder.description("");
+            builder.description(tooltips);
+        }
+
+        return builder.build();
+    }
+
+
+    /**
+     * Create previous button panel item.
+     *
+     * @param template the template
+     * @param slot the slot
+     * @return the panel item
+     */
+    @Nullable
+    private PanelItem createPreviousButton(@NonNull ItemTemplateRecord template, TemplatedPanel.ItemSlot slot)
+    {
+        if (this.pageIndex == 0)
+        {
+            // There are no next elements
+            return null;
+        }
+
+        int previousPageIndex = this.pageIndex;
+
+        PanelItemBuilder builder = new PanelItemBuilder();
+
+        if (template.icon() != null)
+        {
+            ItemStack clone = template.icon().clone();
+
+            if ((Boolean) template.dataMap().getOrDefault("indexing", false))
+            {
+                clone.setAmount(previousPageIndex);
+            }
+
+            builder.icon(clone);
+        }
+
+        if (template.title() != null)
+        {
+            builder.name(this.user.getTranslation(this.world, template.title()));
+        }
+
+        if (template.description() != null)
+        {
+            builder.description(this.user.getTranslation(this.world, template.description(),
+                "[number]", String.valueOf(previousPageIndex)));
+        }
+
+        // Add ClickHandler
+        // Add ClickHandler
+        builder.clickHandler((panel, user, clickType, i) ->
+        {
+            template.actions().forEach(action -> {
+                if (clickType == action.clickType()  || action.clickType() == ClickType.UNKNOWN)
+                {
+                    if ("PREVIOUS".equalsIgnoreCase(action.actionType()))
+                    {
+                        // Next button ignores click type currently.
+                        this.pageIndex--;
+                        this.build();
+                    }
+                }
+            });
+
+            // Always return true.
+            return true;
+        });
+
+        // Collect tooltips.
+        List<String> tooltips = template.actions().stream().
+            filter(action -> action.tooltip() != null).
+            map(action -> this.user.getTranslation(this.world, action.tooltip())).
+            filter(text -> !text.isBlank()).
+            collect(Collectors.toCollection(() -> new ArrayList<>(template.actions().size())));
+
+        // Add tooltips.
+        if (!tooltips.isEmpty())
+        {
+            // Empty line and tooltips.
+            builder.description("");
+            builder.description(tooltips);
+        }
+
+        return builder.build();
+    }
+
+
+    /**
+     * This method creates and returns island button.
+     *
+     * @return PanelItem that represents island button.
+     */
+    @Nullable
+    private PanelItem createPhaseButton(ItemTemplateRecord template, TemplatedPanel.ItemSlot slot)
+    {
+        if (this.elementList.isEmpty())
+        {
+            // Does not contain any sticks.
+            return null;
+        }
+
+        int index = this.pageIndex * slot.amountMap().getOrDefault("PHASE", 1) + slot.slot();
+
+        if (index >= this.elementList.size())
+        {
+            // Out of index.
+            return null;
+        }
+
+        return this.createPhaseButton(template, this.elementList.get(index));
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Other methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This method creates phases button.
+     *
+     * @return PanelItem that allows to select phases button
+     */
+    private PanelItem createPhaseButton(ItemTemplateRecord template, Map.Entry<Integer, OneBlockPhase> phaseEntry)
+    {
+        if (phaseEntry == null || phaseEntry.getValue() == null)
+        {
+            // return as island has no owner. Empty button will be created.
+            return null;
+        }
+
+        OneBlockPhase phase = phaseEntry.getValue();
+        final String reference = "aoneblock.gui.buttons.phase.";
+
+        // Get settings for island.
+        PanelItemBuilder builder = new PanelItemBuilder();
+
+        if (template.icon() != null)
+        {
+            builder.icon(template.icon().clone());
+        }
+        else
+        {
+            ItemStack firstBlock = phase.getFirstBlock() == null ?
+                new ItemStack(Material.STONE) :
+                new ItemStack(phase.getFirstBlock().getMaterial());
+
+            builder.icon(phase.getIconBlock() == null ? firstBlock : phase.getIconBlock());
+        }
+
+        if (template.title() != null)
+        {
+            builder.name(this.user.getTranslation(this.world, template.title(),
+                "[phase]", phase.getPhaseName()));
+        }
+        else
+        {
+            builder.name(this.user.getTranslation(reference + "name",
+                "[phase]", phase.getPhaseName()));
+        }
+
+        // Process Description of the button.
+        String descriptionText;
+
+        final StringBuilder bankText = new StringBuilder();
+        final StringBuilder economyText = new StringBuilder();
+        final StringBuilder permissionText = new StringBuilder();
+        final StringBuilder levelText = new StringBuilder();
+
+        phase.getRequirements().forEach(requirement -> {
+            switch (requirement.getType())
+            {
+                case ECO -> {
+                    economyText.append(this.user.getTranslationOrNothing(reference + "economy",
+                        "[number]", String.valueOf(requirement.getEco())));
+                }
+                case BANK -> {
+                    bankText.append(this.user.getTranslationOrNothing(reference + "bank",
+                        "[number]", String.valueOf(requirement.getBank())));
+                }
+                case LEVEL -> {
+                    levelText.append(this.user.getTranslationOrNothing(reference + "level",
+                        "[number]", String.valueOf(requirement.getLevel())));
+                }
+                case PERMISSION -> {
+                    permissionText.append(this.user.getTranslationOrNothing(reference + "permission",
+                        "[number]", requirement.getPermission()));
+                }
+            }
+        });
+
+        if (template.description() != null)
+        {
+            descriptionText = this.user.getTranslationOrNothing(template.description(),
+                "[number]", phase.getBlockNumber(),
+                "[biome]", LangUtilsHook.getBiomeName(phase.getPhaseBiome(), this.user),
+                "[bank]", bankText.toString(),
+                "[economy]", economyText.toString(),
+                "[level]", levelText.toString(),
+                "[permission]", permissionText.toString());
+        }
+        else
+        {
+            String blockText = this.user.getTranslationOrNothing(reference + "starting-block",
+                "[number]", phase.getBlockNumber());
+            String biomeText = this.user.getTranslationOrNothing(reference + "biome",
+                "[biome]", LangUtilsHook.getBiomeName(phase.getPhaseBiome(), this.user));
+
+            descriptionText = this.user.getTranslationOrNothing(reference + "description",
+                "[starting-block]", biomeText,
+                "[biome]", blockText,
+                "[bank]", bankText.toString(),
+                "[economy]", economyText.toString(),
+                "[level]", levelText.toString(),
+                "[permission]", permissionText.toString());
+        }
+
+        descriptionText = descriptionText.replaceAll("(?m)^[ \\t]*\\r?\\n", "").
+            replaceAll("(?<!\\\\)\\|", "\n").
+            replaceAll("\\\\\\|", "|");
+
+        builder.description(descriptionText);
+
+        // Glow icon if user can select phase.
+
+        boolean canApply;
+
+        if (this.island != null && this.oneBlockIsland != null)
+        {
+            long lifetime = this.oneBlockIsland.getLifetime();
+
+            if (this.oneBlockIsland.getPhaseName().equals(phase.getPhaseName()))
+            {
+                // Players can always reset a phase they are in now.
+                canApply = true;
+            }
+            else if (phase.getBlockNumberValue() < lifetime)
+            {
+                // Check if phase requirements are met.
+                canApply = !this.phaseRequirementsFail(phase);
+            }
+            else
+            {
+                canApply = false;
+            }
+        }
+        else
+        {
+            canApply = false;
+        }
+
+        List<ItemTemplateRecord.ActionRecords> actions = template.actions().stream().
+            filter(action -> switch (action.actionType().toUpperCase()) {
+                case "SELECT" -> canApply;
+                case "VIEW" -> true;
+                default -> false;
+            }).
+            collect(Collectors.toList());
+
+        builder.glow(this.oneBlockIsland != null && this.oneBlockIsland.getPhaseName().equals(phase.getPhaseName()));
+
+        // Add ClickHandler
+        builder.clickHandler((panel, user, clickType, i) ->
+        {
+            actions.forEach(action -> {
+                if (clickType == action.clickType() || action.clickType() == ClickType.UNKNOWN)
+                {
+                    if ("SELECT".equalsIgnoreCase(action.actionType()))
+                    {
+                        this.runCommandCall("setcount", phase);
+                    }
+                    else
+                    {
+                        // TODO: implement view phase panel and command.
+                        //this.runCommandCall("view", phase);
+                    }
+                }
+            });
+
+            // Always return true.
+            return true;
+        });
+
+        // Collect tooltips.
+        List<String> tooltips = actions.stream().
+            filter(action -> action.tooltip() != null).
+            map(action -> this.user.getTranslation(this.world, action.tooltip())).
+            filter(text -> !text.isBlank()).
+            collect(Collectors.toCollection(() -> new ArrayList<>(actions.size())));
+
+        // Add tooltips.
+        if (!tooltips.isEmpty())
+        {
+            // Empty line and tooltips.
+            builder.description("");
+            builder.description(tooltips);
+        }
+
+        return builder.build();
+    }
+
+
+    /**
+     * This method checks if phase requirements fails.
+     * @param phase Phase object.
+     * @return {@code true} if phase requirements fails, {@code false} otherwise.
+     */
+    private boolean phaseRequirementsFail(OneBlockPhase phase)
+    {
+        if (phase.getRequirements().isEmpty())
+        {
+            return false;
+        }
+
+        // Check requirements
+        for (Requirement requirement : phase.getRequirements())
+        {
+            return switch (requirement.getType())
+            {
+                case LEVEL ->
+                    this.addon.getAddonByName("Level").map(addon ->
+                            ((Level) addon).getIslandLevel(this.world, this.island.getOwner()) < requirement.getLevel()).
+                        orElse(false);
+                case BANK ->
+                    this.addon.getAddonByName("Bank").map(addon ->
+                            ((Bank) addon).getBankManager().getBalance(this.island).getValue() < requirement.getBank()).
+                        orElse(false);
+                case ECO ->
+                    this.addon.getPlugin().getVault().map(addon ->
+                            addon.getBalance(this.user, this.world) < requirement.getEco()).
+                        orElse(false);
+                case PERMISSION ->
+                     this.user != null && !this.user.hasPermission(requirement.getPermission());
+            };
+        }
+
+        return false;
+    }
+
+
+    /**
+     * This method runs command call that allows player to visit clicked island.
+     */
+    private void runCommandCall(String command, OneBlockPhase phase)
+    {
+        // Get first player command label.
+        this.addon.getPlayerCommand().ifPresent(mainCommand -> {
+            mainCommand.getSubCommand(command).ifPresent(subCommand -> {
+                if (subCommand.getLabel().equalsIgnoreCase("setcount"))
+                {
+                    this.addon.log(this.user.getName() + " called: `" + mainCommand.getTopLabel() + " " + subCommand.getLabel() + " " + phase.getBlockNumber());
+                    // Confirmation is done via GUI. Bypass.
+                    this.user.performCommand(mainCommand.getTopLabel() + " " + subCommand.getLabel() + " " + phase.getBlockNumber());
+                }
+            });
+        });
+
+        // Close inventory
+        this.user.closeInventory();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Static methods
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This method is used to open UserPanel outside this class. It will be much easier to open panel with single method
+     * call then initializing new object.
+     *
+     * @param addon AOneBLock object
+     * @param world World where user is located.
+     * @param user User who opens panel
+     */
+    public static void openPanel(AOneBlock addon,
+        World world,
+        User user)
+    {
+        new PhasesPanel(addon, world, user).build();
+    }
+
+
+// ---------------------------------------------------------------------
+// Section: Variables
+// ---------------------------------------------------------------------
+
+
+    /**
+     * This variable allows to access addon object.
+     */
+    private final AOneBlock addon;
+
+    /**
+     * This variable holds user who opens panel. Without it panel cannot be opened.
+     */
+    private final User user;
+
+    /**
+     * This variable holds world where panel is opened. Without it panel cannot be opened.
+     */
+    private final World world;
+
+    /**
+     * This variable stores filtered elements.
+     */
+    private final List<Map.Entry<Integer, OneBlockPhase>> elementList;
+
+    /**
+     * This variable stores oneblock island data.
+     */
+    private final OneBlockIslands oneBlockIsland;
+
+    /**
+     * This variable stores oneblock island.
+     */
+    private final Island island;
+
+    /**
+     * This variable holds current pageIndex for multi-page island choosing.
+     */
+    private int pageIndex;
+}

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -46,5 +46,46 @@ aoneblock:
     insufficient-permission: "&c You can proceed no futher until you obtain the [name] permission!"
   placeholders:
     infinite: Infinite
+  gui:
+    titles:
+      phases: '&0&l OneBlock Phases'
+    # This section contains all button names and lore (description)
+    buttons:
+      # List of buttons in GUI's
+      # Button that is used in multi-page GUIs which allows to return to previous page.
+      previous:
+        name: "&f&l Previous Page"
+        description: |-
+          &7 Switch to [number] page
+      # Button that is used in multi-page GUIs which allows to go to next page.
+      next:
+        name: "&f&l Next Page"
+        description: |-
+          &7 Switch to [number] page
+      phase:
+        name: "&f&l [phase]"
+        description: |-
+          [starting-block]
+          [biome]
+          [bank]
+          [economy]
+          [level]
+          [permission]
+        # Replaces text with [starting-block]
+        starting-block: "&7 Starts after breaking &e [number] blocks."
+        # Replaces text with [biome]
+        biome: "&7 Biome: &e [biome]"
+        # Replaces text with [bank]
+        bank: "&7 Requires &e $[number] &7 in bank account."
+        # Replaces text with [economy]
+        economy: "&7 Requires &e $[number] &7 in player account."
+        # Replaces text with [level]
+        level: "&7 Requires &e [number] &7 island level."
+        # Replaces text with [permission]
+        permission: "&7 Requires `&e[permission]&7` permission."
+    tips:
+      click-to-previous: "&e Click &7 to view previous page."
+      click-to-next: "&e Click &7 to view next page."
+      click-to-change: "&e Click &7 to change."
   island:
     starting-hologram: "&aWelcome to AOneBlock\n&eBreak This Block to Begin"

--- a/src/main/resources/panels/phases_panel.yml
+++ b/src/main/resources/panels/phases_panel.yml
@@ -1,0 +1,68 @@
+phases_panel:
+  title: aoneblock.gui.titles.phases
+  type: INVENTORY
+  background:
+    icon: BLACK_STAINED_GLASS_PANE
+    title: "&b&r" # Empty text
+  border:
+    icon: BLACK_STAINED_GLASS_PANE
+    title: "&b&r"  # Empty text
+  force-shown: []
+  content:
+    2:
+      2: phase_button
+      3: phase_button
+      4: phase_button
+      5: phase_button
+      6: phase_button
+      7: phase_button
+      8: phase_button
+    3:
+      1:
+        icon: TIPPED_ARROW:INSTANT_HEAL::::1
+        title: aoneblock.gui.buttons.previous.name
+        description: aoneblock.gui.buttons.previous.description
+        data:
+          type: PREVIOUS
+          indexing: true
+        actions:
+          previous:
+            click-type: LEFT
+            tooltip: aoneblock.gui.tips.click-to-previous
+      2: phase_button
+      3: phase_button
+      4: phase_button
+      5: phase_button
+      6: phase_button
+      7: phase_button
+      8: phase_button
+      9:
+        icon: TIPPED_ARROW:JUMP::::1
+        title: aoneblock.gui.buttons.next.name
+        description: aoneblock.gui.buttons.next.description
+        data:
+          type: NEXT
+          indexing: true
+        actions:
+          next:
+            click-type: LEFT
+            tooltip: aoneblock.gui.tips.click-to-next
+    4:
+      2: phase_button
+      3: phase_button
+      4: phase_button
+      5: phase_button
+      6: phase_button
+      7: phase_button
+      8: phase_button
+  reusable:
+    phase_button:
+      # icon: PLAYER_HEAD
+      # title: aoneblock.gui.buttons.phase.name
+      # description: aoneblock.gui.buttons.phase.description
+      data:
+        type: PHASE
+      actions:
+        select:
+          click-type: LEFT
+          tooltip: aoneblock.gui.tips.click-to-change


### PR DESCRIPTION
This panel can allow viewing and change phase for players. 

Instead of a hard-codded panel that only displayed phases, users will be able to use this panel to customize it looks and change the current player phase.

Part of https://github.com/BentoBoxWorld/BentoBox/issues/1931