### PR TITLE
Respawn command

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -17,8 +17,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.gmail.filoghost.holographicdisplays.api.Hologram;
 import com.gmail.filoghost.holographicdisplays.api.HologramsAPI;
 
-import world.bentobox.aoneblock.commands.AdminCommand;
-import world.bentobox.aoneblock.commands.PlayerCommand;
+import world.bentobox.aoneblock.commands.admin.AdminCommand;
+import world.bentobox.aoneblock.commands.island.PlayerCommand;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.generators.ChunkGeneratorWorld;
 import world.bentobox.aoneblock.listeners.BlockListener;

--- a/src/main/java/world/bentobox/aoneblock/commands/admin/AdminCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/admin/AdminCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.admin;
 
 import world.bentobox.bentobox.api.addons.GameModeAddon;
 import world.bentobox.bentobox.api.commands.admin.DefaultAdminCommand;

--- a/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSanityCheck.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSanityCheck.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.admin;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSetChestCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSetChestCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.admin;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSetCountCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/admin/AdminSetCountCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.admin;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/world/bentobox/aoneblock/commands/island/IslandAboutCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/IslandAboutCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.island;
 
 import java.util.List;
 

--- a/src/main/java/world/bentobox/aoneblock/commands/island/IslandCountCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/IslandCountCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.island;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.island;
 
 import java.util.Comparator;
 import java.util.List;

--- a/src/main/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommand.java
@@ -1,0 +1,117 @@
+package world.bentobox.aoneblock.commands.island;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.util.Vector;
+import java.util.List;
+
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
+
+
+/**
+ * This command checks if center block is AIR or BEDROCK and in such situation it triggers BlockBreakEvent.
+ */
+public class IslandRespawnBlockCommand extends CompositeCommand
+{
+    /**
+     * Instantiates a new Island respawn block command.
+     *
+     * @param islandCommand the island command
+     */
+    public IslandRespawnBlockCommand(CompositeCommand islandCommand)
+    {
+        super(islandCommand, "respawnblock");
+    }
+
+
+    @Override
+    public void setup()
+    {
+        this.setDescription("aoneblock.commands.respawn-block.description");
+        this.setOnlyPlayer(true);
+        // Permission
+        this.setPermission("respawn-block");
+    }
+
+
+    @Override
+    public boolean canExecute(User user, String label, List<String> args)
+    {
+        if (!Util.sameWorld(getWorld(), user.getWorld()))
+        {
+            user.sendMessage("general.errors.wrong-world");
+            return false;
+        }
+
+        Island island = this.getIslands().getIsland(this.getWorld(), user);
+
+        if (island == null)
+        {
+            user.sendMessage("general.errors.no-island");
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public boolean execute(User user, String label, List<String> args)
+    {
+        Island island = this.getIslands().getIsland(this.getWorld(), user);
+
+        if (island == null)
+        {
+            // Hmm, lost island so fast. Well, no, just idea null-pointer check bypass.
+            user.sendMessage("general.errors.no-island");
+        }
+        else if (Material.BEDROCK.equals(island.getCenter().getBlock().getType()) ||
+            Material.AIR.equals(island.getCenter().getBlock().getType()))
+        {
+            // Trigger manual block break event.
+            Bukkit.getServer().getPluginManager().callEvent(
+                new BlockBreakEvent(island.getCenter().getBlock(), user.getPlayer()));
+
+            user.sendMessage("aoneblock.commands.respawn-block.block-respawned");
+        }
+        else
+        {
+            // Spawn 6 particles where block is located.
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(0.5, 1.0, 0.5)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(1.0, 0.5, 0.5)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(0.5, 0.5, 1.0)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(0.5, 0.0, 0.5)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(0.0, 0.5, 0.5)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+            island.getWorld().spawnParticle(Particle.REDSTONE,
+                island.getCenter().add(new Vector(0.5, 0.5, 0.0)),
+                5, 0.1, 0, 0.1, 1,
+                new Particle.DustOptions(Color.fromBGR(0, 100, 0), 1));
+
+            user.sendMessage("aoneblock.commands.respawn-block.block-exist");
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.island;
 
 import java.util.List;
 

--- a/src/main/java/world/bentobox/aoneblock/commands/island/PlayerCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/PlayerCommand.java
@@ -1,4 +1,4 @@
-package world.bentobox.aoneblock.commands;
+package world.bentobox.aoneblock.commands.island;
 
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.bentobox.api.commands.island.DefaultPlayerCommand;

--- a/src/main/java/world/bentobox/aoneblock/commands/island/PlayerCommand.java
+++ b/src/main/java/world/bentobox/aoneblock/commands/island/PlayerCommand.java
@@ -21,6 +21,8 @@ public class PlayerCommand extends DefaultPlayerCommand {
         new IslandPhasesCommand(this);
         // Set Count
         new IslandSetCountCommand(this);
+        // Force block respawn
+        new IslandRespawnBlockCommand(this);
     }
 
 }

--- a/src/main/resources/addon.yml
+++ b/src/main/resources/addon.yml
@@ -18,6 +18,9 @@ permissions:
   aoneblock.phases:
     description: Allow the use of the phases command
     default: false
+  aoneblock.respawn-block:
+    description: Allow the use of use block respawn command.
+    default: true
   aoneblock.island:
    description: Allow island command usage
    default: true

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -39,6 +39,10 @@ aoneblock:
         description: "set block count to previously completed value"
         set: "&a Count set to [number]."
         too-high: "&c The maximum you can set is [number]!"
+    respawn-block:
+      description: "respawns magic block in situations when they disappear"
+      block-exist: "&a Block exist, do not require respawning. I marked it for you."
+      block-respawned: "&a Block respawned, please, do not void it again."
   phase:
     insufficient-level: "&c Your island level is too low to proceed! It must be [number]."
     insufficient-funds: "&c Your funds are too low to proceed! They must be [number]."


### PR DESCRIPTION
Adds a new command to users: `[player_cmd] respawnblock`.

This command allows respawning magic block in situations when it disappears. It is done by calling manually `BreakBlockEvent`. It may try to respawn entities, but in general, it should work.

It should be a good workaround for issues when the magic block disappears:
#238, #237, #156