### PR TITLE
Fix random block issues

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
+++ b/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
@@ -1,7 +1,8 @@
 package world.bentobox.aoneblock.dataobjects;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 import org.bukkit.entity.EntityType;
 import org.eclipse.jdt.annotation.NonNull;
 
@@ -41,7 +42,7 @@ public class OneBlockIslands implements DataObject {
     @Expose
     private String hologram = "";
 
-    private List<OneBlockObject> queue = new ArrayList<>();
+    private Queue<OneBlockObject> queue = new LinkedList<>();
 
     /**
      * @return the phaseName
@@ -121,8 +122,8 @@ public class OneBlockIslands implements DataObject {
     /**
      * @return the queue
      */
-    public List<OneBlockObject> getQueue() {
-        if (queue == null) queue = new ArrayList<>();
+    public Queue<OneBlockObject> getQueue() {
+        if (queue == null) queue = new LinkedList<>();
         return queue;
     }
 
@@ -141,8 +142,7 @@ public class OneBlockIslands implements DataObject {
 
     public OneBlockObject pollAndAdd(OneBlockObject toAdd) {
         getQueue();
-        OneBlockObject b = queue.get(0);
-        queue.remove(0);
+        OneBlockObject b = queue.poll();
         queue.add(toAdd);
         return b;
     }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -46,7 +46,8 @@ public class OneBlockPhase {
     private OneBlockObject firstBlock;
     private ItemStack iconBlock;
     private final Map<Rarity, List<OneBlockObject>> chests = new EnumMap<>(Rarity.class);
-    private final Random random = new Random();
+    private final Random blockRandom;
+    private final Random chestRandom;
     private final String blockNumber;
     private Integer gotoBlock;
     private int blockTotal = 0;
@@ -70,6 +71,11 @@ public class OneBlockPhase {
         requirements = new ArrayList<>();
         fixedBlocks = new HashMap<>();
         holograms = new HashMap<>();
+
+        // Separate chest and block random.
+        // May be expose random to users?
+        blockRandom = new Random();
+        chestRandom = new Random();
     }
 
     /**
@@ -195,28 +201,31 @@ public class OneBlockPhase {
 
     private OneBlockObject getRandomChest() {
         // Get the right type of chest
-        Rarity r = CHEST_CHANCES.getOrDefault(((TreeMap<Double, Rarity>) CHEST_CHANCES).ceilingKey(random.nextDouble()),
+        Rarity r = CHEST_CHANCES.getOrDefault(((TreeMap<Double, Rarity>) CHEST_CHANCES).ceilingKey(this.chestRandom.nextDouble()),
                 Rarity.COMMON);
         // If the chest lists have no common fallback, then return empty chest
-        if (!chests.containsKey(r) && !chests.containsKey(Rarity.COMMON)) {
+        if (!this.chests.containsKey(r) && !this.chests.containsKey(Rarity.COMMON)) {
             return new OneBlockObject(Material.CHEST, 0);
         }
         // Get the rare chest or worse case the common one
-        List<OneBlockObject> list = chests.containsKey(r) ? chests.get(r) : chests.get(Rarity.COMMON);
+        List<OneBlockObject> list = this.chests.containsKey(r) ? this.chests.get(r) : this.chests.get(Rarity.COMMON);
         // Pick one from the list or return an empty chest. Note list.get() can return
         // nothing
-        return list.isEmpty() ? new OneBlockObject(Material.CHEST, 0) : list.get(random.nextInt(list.size()));
+        return list.isEmpty() ? new OneBlockObject(Material.CHEST, 0) : list.get(this.chestRandom.nextInt(list.size()));
     }
 
     private OneBlockObject getRandomBlock(TreeMap<Integer, OneBlockObject> probMap2, int total2) {
         // Use +1 on the bound because the random choice is exclusive
-        OneBlockObject temp = probMap2.get(random.nextInt(total2 + 1));
+        int randomValue = this.blockRandom.nextInt(total2 + 1);
+
+        OneBlockObject temp = probMap2.get(randomValue);
         if (temp == null) {
-            temp = probMap2.ceilingEntry(random.nextInt(total2 + 1)).getValue();
+            temp = probMap2.ceilingEntry(randomValue).getValue();
         }
         if (temp == null) {
             temp = probMap2.firstEntry().getValue();
         }
+
         return new OneBlockObject(temp);
     }
 


### PR DESCRIPTION
It was noticed that random blocks with rare chances were generating too freequently. 
I noticed that it calculated 2 different random values for block calculation, which increases the chance of a random block 2 times.

Also, the Next Oneblock Queue was incorrectly created. It used ArrayList which is the worst possible solution for it.
I switch it to Queue and LinkedList as it is exactly what is necessary for a block queue.