### PR TITLE
Custom Block support

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -600,6 +600,11 @@ public class BlockListener implements Listener {
 
 
     private void spawnBlock(@NonNull OneBlockObject nextBlock, @NonNull Block block) {
+        if (nextBlock.isCustomBlock()) {
+            nextBlock.getCustomBlock().setBlock(block);
+            return;
+        }
+
         @NonNull
         Material type = nextBlock.getMaterial();
         // Place new block with no physics

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
@@ -1,0 +1,11 @@
+package world.bentobox.aoneblock.oneblocks;
+
+import org.bukkit.block.Block;
+
+import java.util.Map;
+
+public interface OneBlockCustomBlock {
+    boolean isValid(Map<String, Object> map);
+
+    void setBlock(Block block);
+}

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
@@ -2,10 +2,16 @@ package world.bentobox.aoneblock.oneblocks;
 
 import org.bukkit.block.Block;
 
-import java.util.Map;
-
+/**
+ * Represents a custom block
+ *
+ * @author HSGamer
+ */
 public interface OneBlockCustomBlock {
-    boolean isValid(Map<String, Object> map);
-
+    /**
+     * Set the block
+     *
+     * @param block the block
+     */
     void setBlock(Block block);
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
@@ -1,0 +1,50 @@
+package world.bentobox.aoneblock.oneblocks;
+
+import world.bentobox.aoneblock.oneblocks.customblock.BlockDataCustomBlock;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A creator for {@link OneBlockCustomBlock}
+ *
+ * @author HSGamer
+ */
+public final class OneBlockCustomBlockCreator {
+    private static final Map<String, Function<Map<?, ?>, Optional<? extends OneBlockCustomBlock>>> creatorMap = new LinkedHashMap<>();
+
+    static {
+        register("block-data", BlockDataCustomBlock::fromMap);
+    }
+
+    private OneBlockCustomBlockCreator() {
+        // EMPTY
+    }
+
+    /**
+     * Register a creator
+     *
+     * @param type    the type
+     * @param creator the creator
+     */
+    public static void register(String type, Function<Map<?, ?>, Optional<? extends OneBlockCustomBlock>> creator) {
+        creatorMap.put(type, creator);
+    }
+
+    /**
+     * Create a custom block from the map
+     *
+     * @param map the map
+     * @return the custom block
+     */
+    public static Optional<OneBlockCustomBlock> create(Map<?, ?> map) {
+        String type = Objects.toString(map.get("type"), null);
+        if (type == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(creatorMap.get(type)).flatMap(builder -> builder.apply(map));
+    }
+}

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockObject.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockObject.java
@@ -41,6 +41,7 @@ public class OneBlockObject {
     private Material material;
     private Map<Integer, ItemStack> chest;
     private Rarity rarity;
+    private OneBlockCustomBlock customBlock;
     private int prob;
 
     /**
@@ -63,7 +64,17 @@ public class OneBlockObject {
     public OneBlockObject(Material material, int prob) {
         this.material = material;
         this.prob = prob;
+    }
 
+    /**
+     * A custom block
+     *
+     * @param customBlock - custom block
+     * @param prob        - relative probability
+     */
+    public OneBlockObject(OneBlockCustomBlock customBlock, int prob) {
+        this.customBlock = customBlock;
+        this.prob = prob;
     }
 
 
@@ -76,7 +87,6 @@ public class OneBlockObject {
         this.material = Material.CHEST;
         this.chest = chest;
         this.setRarity(rarity);
-
     }
 
     /**
@@ -90,6 +100,7 @@ public class OneBlockObject {
         this.material = ob.getMaterial();
         this.rarity = ob.getRarity();
         this.prob = ob.getProb();
+        this.customBlock = ob.getCustomBlock();
     }
 
     /**
@@ -117,6 +128,14 @@ public class OneBlockObject {
 
 
     /**
+     * @return the customBlock
+     */
+    public OneBlockCustomBlock getCustomBlock() {
+        return customBlock;
+    }
+
+
+    /**
      * @return the isMaterial
      */
     public boolean isMaterial() {
@@ -129,6 +148,14 @@ public class OneBlockObject {
      */
     public boolean isEntity() {
         return entityType != null;
+    }
+
+
+    /**
+     * @return the isCustomBlock
+     */
+    public boolean isCustomBlock() {
+        return customBlock != null;
     }
 
     /**
@@ -167,6 +194,7 @@ public class OneBlockObject {
         return "OneBlockObject [" + (entityType != null ? "entityType=" + entityType + ", " : "")
                 + (material != null ? "material=" + material + ", " : "")
                 + (chest != null ? "chest=" + chest + ", " : "") + (rarity != null ? "rarity=" + rarity + ", " : "")
+                + (customBlock != null ? "customBlock=" + customBlock + ", " : "")
                 + "prob=" + prob + "]";
     }
 

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -1,25 +1,16 @@
 package world.bentobox.aoneblock.oneblocks;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
-
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.oneblocks.OneBlockObject.Rarity;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class OneBlockPhase {
     protected static final SortedMap<Double, Rarity> CHEST_CHANCES = new TreeMap<>();
@@ -36,6 +27,10 @@ public class OneBlockPhase {
      * all probabilities
      */
     private final TreeMap<Integer, OneBlockObject> probMap = new TreeMap<>();
+    private final Map<Rarity, List<OneBlockObject>> chests = new EnumMap<>(Rarity.class);
+    private final Random blockRandom;
+    private final Random chestRandom;
+    private final String blockNumber;
     /**
      * Sum of all probabilities
      */
@@ -45,10 +40,6 @@ public class OneBlockPhase {
     private Environment environment;
     private OneBlockObject firstBlock;
     private ItemStack iconBlock;
-    private final Map<Rarity, List<OneBlockObject>> chests = new EnumMap<>(Rarity.class);
-    private final Random blockRandom;
-    private final Random chestRandom;
-    private final String blockNumber;
     private Integer gotoBlock;
     private int blockTotal = 0;
     private int entityTotal = 0;
@@ -110,6 +101,13 @@ public class OneBlockPhase {
     }
 
     /**
+     * @param hologramLines the hologramLines to set
+     */
+    public void setHologramLines(Map<Integer, String> hologramLines) {
+        this.holograms = hologramLines;
+    }
+
+    /**
      * @return the phaseName or null if it is not set yet
      */
     @Nullable
@@ -149,6 +147,18 @@ public class OneBlockPhase {
         total += prob;
         blockTotal += prob;
         probMap.put(total, new OneBlockObject(material, prob));
+    }
+
+    /**
+     * Adds a custom block and associated probability
+     *
+     * @param customBlock - custom block
+     * @param prob        - probability
+     */
+    public void addCustomBlock(OneBlockCustomBlock customBlock, int prob) {
+        total += prob;
+        blockTotal += prob;
+        probMap.put(total, new OneBlockObject(customBlock, prob));
     }
 
     /**
@@ -252,18 +262,18 @@ public class OneBlockPhase {
     }
 
     /**
+     * @param firstBlock the firstBlock to set
+     */
+    public void setFirstBlock(OneBlockObject firstBlock) {
+        this.firstBlock = firstBlock;
+    }
+
+    /**
      * @return the iconBlock
      */
     @Nullable
     public ItemStack getIconBlock() {
         return iconBlock;
-    }
-
-    /**
-     * @param firstBlock the firstBlock to set
-     */
-    public void setFirstBlock(OneBlockObject firstBlock) {
-        this.firstBlock = firstBlock;
     }
 
     /**
@@ -405,12 +415,5 @@ public class OneBlockPhase {
      */
     public void setFixedBlocks(Map<Integer, OneBlockObject> fixedBlocks) {
         this.fixedBlocks = fixedBlocks;
-    }
-
-    /**
-     * @param hologramLines the hologramLines to set
-     */
-    public void setHologramLines(Map<Integer, String> hologramLines) {
-        this.holograms = hologramLines;
     }
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -1,16 +1,25 @@
 package world.bentobox.aoneblock.oneblocks;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.eclipse.jdt.annotation.Nullable;
+
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.oneblocks.OneBlockObject.Rarity;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class OneBlockPhase {
     protected static final SortedMap<Double, Rarity> CHEST_CHANCES = new TreeMap<>();
@@ -27,10 +36,6 @@ public class OneBlockPhase {
      * all probabilities
      */
     private final TreeMap<Integer, OneBlockObject> probMap = new TreeMap<>();
-    private final Map<Rarity, List<OneBlockObject>> chests = new EnumMap<>(Rarity.class);
-    private final Random blockRandom;
-    private final Random chestRandom;
-    private final String blockNumber;
     /**
      * Sum of all probabilities
      */
@@ -40,6 +45,10 @@ public class OneBlockPhase {
     private Environment environment;
     private OneBlockObject firstBlock;
     private ItemStack iconBlock;
+    private final Map<Rarity, List<OneBlockObject>> chests = new EnumMap<>(Rarity.class);
+    private final Random blockRandom;
+    private final Random chestRandom;
+    private final String blockNumber;
     private Integer gotoBlock;
     private int blockTotal = 0;
     private int entityTotal = 0;
@@ -98,13 +107,6 @@ public class OneBlockPhase {
      */
     public Map<Integer, String> getHologramLines() {
         return holograms;
-    }
-
-    /**
-     * @param hologramLines the hologramLines to set
-     */
-    public void setHologramLines(Map<Integer, String> hologramLines) {
-        this.holograms = hologramLines;
     }
 
     /**
@@ -262,18 +264,18 @@ public class OneBlockPhase {
     }
 
     /**
-     * @param firstBlock the firstBlock to set
-     */
-    public void setFirstBlock(OneBlockObject firstBlock) {
-        this.firstBlock = firstBlock;
-    }
-
-    /**
      * @return the iconBlock
      */
     @Nullable
     public ItemStack getIconBlock() {
         return iconBlock;
+    }
+
+    /**
+     * @param firstBlock the firstBlock to set
+     */
+    public void setFirstBlock(OneBlockObject firstBlock) {
+        this.firstBlock = firstBlock;
     }
 
     /**
@@ -415,5 +417,12 @@ public class OneBlockPhase {
      */
     public void setFixedBlocks(Map<Integer, OneBlockObject> fixedBlocks) {
         this.fixedBlocks = fixedBlocks;
+    }
+
+    /**
+     * @param hologramLines the hologramLines to set
+     */
+    public void setHologramLines(Map<Integer, String> hologramLines) {
+        this.holograms = hologramLines;
     }
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -48,7 +48,7 @@ public class OneBlocksManager {
     private static final String MOBS = "mobs";
     private static final String BLOCKS = "blocks";
     private static final String PHASES = "phases";
-    private static final String CUSTOM_BLOCKS = "customBlocks";
+    private static final String CUSTOM_BLOCKS = "custom-blocks";
     private static final String GOTO_BLOCK = "gotoBlock";
     private static final String START_COMMANDS = "start-commands";
     private static final String END_COMMANDS = "end-commands";

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -417,7 +417,7 @@ public class OneBlocksManager {
         try {
             prob = Integer.parseInt(probability);
         } catch (Exception e) {
-            prob = 0;
+            return false;
         }
 
         if (m == null || !m.isBlock()) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -48,6 +48,7 @@ public class OneBlocksManager {
     private static final String MOBS = "mobs";
     private static final String BLOCKS = "blocks";
     private static final String PHASES = "phases";
+    private static final String CUSTOM_BLOCKS = "customBlocks";
     private static final String GOTO_BLOCK = "gotoBlock";
     private static final String START_COMMANDS = "start-commands";
     private static final String END_COMMANDS = "end-commands";
@@ -389,6 +390,14 @@ public class OneBlocksManager {
             }
 
         }
+    }
+
+    void addCustom(OneBlockPhase obPhase, ConfigurationSection phase) {
+        if (!phase.isConfigurationSection(CUSTOM_BLOCKS)) {
+            return;
+        }
+        ConfigurationSection customs = phase.getConfigurationSection(CUSTOM_BLOCKS);
+        // TODO
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
@@ -1,0 +1,40 @@
+package world.bentobox.aoneblock.oneblocks.customblock;
+
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
+import world.bentobox.bentobox.BentoBox;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A custom block that is defined by a block data value.
+ *
+ * @author HSGamer
+ */
+public class BlockDataCustomBlock implements OneBlockCustomBlock {
+    private final String blockData;
+
+    public BlockDataCustomBlock(String blockData) {
+        this.blockData = blockData;
+    }
+
+    public static Optional<BlockDataCustomBlock> fromMap(Map<?, ?> map) {
+        if (map.containsKey("data")) {
+            return Optional.of(new BlockDataCustomBlock(Objects.toString(map.get("data"))));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void setBlock(Block block) {
+        try {
+            block.setBlockData(Bukkit.createBlockData(blockData));
+        } catch (IllegalArgumentException e) {
+            BentoBox.getInstance().logError("Could not set block data " + blockData + " for block " + block.getType());
+        }
+    }
+}


### PR DESCRIPTION
This adds an interface called `OneBlockCustomBlock` and a creator called `OneBlockCustomBlockCreator` that can be used by other addons to register custom blocks to the phases.

For the phase config, this adds a new approach to `blocks` with the example format
```yaml
blocks:
- type: data
  data: minecraft:chest[waterlogged=true]
  probability: 10
- type: data
  data: minecraft:chest
  probability: 10
- DIRT: 10 
```
The `data` type is a built-in custom block type. Developers can add more types to the creator and parse the map (an entry of the list) to their own custom block.

Also, `fixed-blocks` supports custom blocks, alongside with the current material name.
```yaml
fixedBlocks:
    0:
      type: data
      data: minecraft:chest[waterlogged=true]
    1: GRASS_BLOCK
    2: GRASS_BLOCK
```