### PR TITLE
Improve hologram support

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -129,6 +129,9 @@ public class AOneBlock extends GameModeAddon {
     public void onDisable() {
         // save cache
         blockListener.saveCache();
+
+        // Clear holograms
+        holoListener.clear();
     }
 
     @Override
@@ -250,6 +253,9 @@ public class AOneBlock extends GameModeAddon {
     public void allLoaded() {
         // save settings. This will occur after all addons have loaded
         this.saveWorldSettings();
+
+        // Manage Old Holograms
+        holoListener.setUp();
     }
 
     /**
@@ -287,12 +293,4 @@ public class AOneBlock extends GameModeAddon {
     public HoloListener getHoloListener() {
         return holoListener;
     }
-
-    /**
-     * @return whether to use Holographic Displays or Not
-     */
-    public boolean useHolographicDisplays() {
-        return settings.isUseHolograms();
-    }
-
 }

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -332,9 +332,7 @@ public class BlockListener implements Listener {
         OneBlockIslands is = new OneBlockIslands(island.getUniqueId());
         cache.put(island.getUniqueId(), is);
         handler.saveObjectAsync(is);
-        if (addon.useHolographicDisplays()) {
-            addon.getHoloListener().setUp(island, is);
-        }
+        addon.getHoloListener().setUp(island, is, true);
     }
 
 
@@ -389,9 +387,7 @@ public class BlockListener implements Listener {
             }
         }
         // Manage Holograms
-        if (addon.useHolographicDisplays()) {
-            addon.getHoloListener().process(i, is, phase);
-        }
+        addon.getHoloListener().process(i, is, phase);
         // Play warning sound for upcoming mobs
         if (addon.getSettings().getMobWarning() > 0) {
             playWarning(is, block);

--- a/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
@@ -54,7 +54,7 @@ public class HoloListener implements Listener {
         assert world != null;
 
         TextDisplay newDisplay = world.spawn(pos, TextDisplay.class);
-        newDisplay.setAlignment(TextAligment.CENTER);
+        newDisplay.setAlignment(TextDisplay.TextAlignment.CENTER);
         newDisplay.setBillboard(Billboard.CENTER);
 
         cachedHolograms.put(island, newDisplay);

--- a/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
@@ -16,6 +16,7 @@ import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
 import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.util.Util;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -137,7 +138,7 @@ public class HoloListener implements Listener {
 
     protected void process(@NonNull Island i, @NonNull OneBlockIslands is, @NonNull OneBlockPhase phase) {
         String holoLine = phase.getHologramLine(is.getBlockNumber());
-        is.setHologram(holoLine == null ? "" : holoLine);
+        is.setHologram(holoLine == null ? "" : Util.translateColorCodes(holoLine));
         updateLines(i, is);
     }
 }

--- a/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
@@ -70,7 +70,7 @@ public class HoloListener implements Listener {
 
     private void updateLines(Island island, OneBlockIslands oneBlockIsland) {
         // Ignore if holograms are disabled
-        if (addon.getSettings().isUseHolograms()) {
+        if (!addon.getSettings().isUseHolograms()) {
             return;
         }
 

--- a/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/HoloListener.java
@@ -2,17 +2,14 @@ package world.bentobox.aoneblock.listeners;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Display.Billboard;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.TextDisplay;
 import org.bukkit.entity.TextDisplay.TextAligment;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.eclipse.jdt.annotation.NonNull;
-
-import net.md_5.bungee.api.ChatColor;
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
@@ -20,71 +17,127 @@ import world.bentobox.bentobox.api.events.island.IslandDeleteEvent;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.objects.Island;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
 /**
- * Handles Holographic elements. Relies on Holographic Plugin
- * @author tastybento
+ * Handles Holographic elements
+ *
+ * @author tastybento, HSGamer
  */
 public class HoloListener implements Listener {
-
     private final AOneBlock addon;
+    private final Map<Island, TextDisplay> cachedHolograms;
 
     /**
      * @param addon - OneBlock
      */
     public HoloListener(@NonNull AOneBlock addon) {
         this.addon = addon;
+        this.cachedHolograms = new IdentityHashMap<>();
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onDeletedIsland(IslandDeleteEvent e) {
-        deleteOldHolograms(e.getIsland());
+        deleteHologram(e.getIsland());
+    }
+
+    private Optional<TextDisplay> getHologram(Island island) {
+        return Optional.ofNullable(cachedHolograms.get(island)).filter(TextDisplay::isValid);
+    }
+
+    private TextDisplay createHologram(Island island) {
+        Location pos = island.getCenter().clone().add(0.5, 1.1, 0.5);
+        World world = pos.getWorld();
+        assert world != null;
+
+        TextDisplay newDisplay = world.spawn(pos, TextDisplay.class);
+        newDisplay.setAlignment(TextAligment.CENTER);
+        newDisplay.setBillboard(Billboard.CENTER);
+
+        cachedHolograms.put(island, newDisplay);
+
+        return newDisplay;
+    }
+
+    private void clearIfInitialized(TextDisplay hologram) {
+        if (hologram.isValid()) {
+            hologram.remove();
+        }
+    }
+
+    private void updateLines(Island island, OneBlockIslands oneBlockIsland) {
+        // Ignore if holograms are disabled
+        if (addon.getSettings().isUseHolograms()) {
+            return;
+        }
+
+        Optional<TextDisplay> optionalHologram = getHologram(island);
+        String holoLine = oneBlockIsland.getHologram();
+
+        // Clear hologram if empty
+        if (holoLine.isEmpty() && optionalHologram.isPresent()) {
+            clearIfInitialized(optionalHologram.get());
+            return;
+        }
+
+        // Get or create hologram if needed
+        TextDisplay hologram = optionalHologram.orElseGet(() -> createHologram(island));
+
+        // Convert and set lines to hologram
+        hologram.setText(holoLine);
+
+        // Set up auto delete
+        if (addon.getSettings().getHologramDuration() > 0) {
+            Bukkit.getScheduler().runTaskLater(addon.getPlugin(), () -> clearIfInitialized(hologram), addon.getSettings().getHologramDuration() * 20L);
+        }
     }
 
     /**
-     * Delete old holograms
-     * @param island island
+     * Setup holograms on startup
      */
-    private void deleteOldHolograms(@NonNull Island island) {
-        island.getWorld().getEntities().stream().filter(e -> e instanceof TextDisplay).filter(e -> island.onIsland(e.getLocation())).forEach(Entity::remove);
+    public void setUp() {
+        addon.getIslands().getIslands().stream()
+                .filter(i -> addon.inWorld(i.getWorld()))
+                .forEach(island -> setUp(island, addon.getOneBlocksIsland(island), false));
     }
 
-    protected void setUp(@NonNull Island island, @NonNull OneBlockIslands is) {
-        // Delete Old Holograms
-        deleteOldHolograms(island);
-        // Manage New Hologram
-        if (island.getOwner() != null) {
-            User owner = User.getInstance(island.getOwner());
-            String hololine = owner.getTranslation("aoneblock.island.starting-hologram");
-            is.setHologram(hololine == null ? "" : hololine);
-            Location center = island.getCenter();
-            showHologram(hololine, center);            
+    public void clear() {
+        cachedHolograms.values().forEach(this::clearIfInitialized);
+        cachedHolograms.clear();
+    }
+
+    /**
+     * Delete hologram
+     *
+     * @param island island
+     */
+    private void deleteHologram(@NonNull Island island) {
+        TextDisplay hologram = cachedHolograms.remove(island);
+        if (hologram != null) {
+            clearIfInitialized(hologram);
         }
     }
 
-    private void showHologram(String hololine, Location center) {      
-        if (hololine != null && center != null) {
-            Location pos = center.clone().add(0.5, 1.1, 0.5);
-            center.getWorld().getEntities().stream().filter(e -> e instanceof TextDisplay).filter(e -> e.getLocation().getBlockX() == pos.getBlockX()
-                    && e.getLocation().getBlockY() == pos.getBlockY()
-                    && e.getLocation().getBlockZ() == pos.getBlockZ()).forEach(Entity::remove);
-            TextDisplay td = (TextDisplay) center.getWorld().spawnEntity(pos, EntityType.TEXT_DISPLAY);
-            td.setText(hololine);
-            td.setAlignment(TextAligment.CENTER);
-            td.setBillboard(Billboard.CENTER);
-            // Kill hologram
-            Bukkit.getScheduler().runTaskLater(addon.getPlugin(), () -> {
-                if (td != null) td.remove();
-            }, addon.getSettings().getHologramDuration() * 20L);
-        }        
+    protected void setUp(@NonNull Island island, @NonNull OneBlockIslands is, boolean newIsland) {
+        UUID ownerUUID = island.getOwner();
+        if (ownerUUID == null) {
+            return;
+        }
+
+        User owner = User.getInstance(ownerUUID);
+        if (newIsland) {
+            String holoLine = owner.getTranslation("aoneblock.island.starting-hologram");
+            is.setHologram(holoLine == null ? "" : holoLine);
+        }
+        updateLines(island, is);
     }
 
     protected void process(@NonNull Island i, @NonNull OneBlockIslands is, @NonNull OneBlockPhase phase) {
-        String text = phase.getHologramLine(is.getBlockNumber());
-        if (text != null) {
-            String hololine = ChatColor.translateAlternateColorCodes('&', text);
-            is.setHologram(hololine == null ? "" : hololine);
-            Location center = i.getCenter();
-            showHologram(hololine, center);
-        }
+        String holoLine = phase.getHologramLine(is.getBlockNumber());
+        is.setHologram(holoLine == null ? "" : holoLine);
+        updateLines(i, is);
     }
 }

--- a/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
+++ b/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
@@ -329,14 +329,4 @@ public class AOneBlockTest {
     public void testGetHoloListener() {
         assertNull(addon.getHoloListener());
     }
-
-    /**
-     * Test method for {@link world.bentobox.aoneblock.AOneBlock#useHolographicDisplays()}.
-     */
-    @Test
-    public void testUseHolographicDisplays() {
-        addon.onLoad();
-        assertTrue(addon.useHolographicDisplays());
-    }
-
 }


### PR DESCRIPTION
This is a continuation of #306, but this time it uses the new `TextDisplay` API.

The addon will cache the `TextDisplay` for:
- Future use: Only create the new display if it does not exist.
- Marked deletion: Only delete the display related to the feature. There would be more displays from other plugins / addons, so we don't want to delete them just to update ours.