### PR TITLE
Custom Block support as a string

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
@@ -16,6 +16,13 @@ public final class OneBlockCustomBlockCreator {
 
     static {
         register("block-data", BlockDataCustomBlock::fromMap);
+        register("short", map -> {
+            String type = Objects.toString(map.get("data"), null);
+            if (type == null) {
+                return Optional.empty();
+            }
+            return create(type);
+        });
     }
 
     private OneBlockCustomBlockCreator() {
@@ -56,14 +63,14 @@ public final class OneBlockCustomBlockCreator {
     }
 
     /**
-     * Create a custom block from the short type
+     * Create a custom block from the string value
      *
-     * @param type the short type
+     * @param value the value
      * @return the custom block
      */
-    public static Optional<OneBlockCustomBlock> create(String type) {
+    public static Optional<OneBlockCustomBlock> create(String value) {
         for (Function<String, Optional<? extends OneBlockCustomBlock>> creator : shortCreatorList) {
-            Optional<? extends OneBlockCustomBlock> customBlock = creator.apply(type);
+            Optional<? extends OneBlockCustomBlock> customBlock = creator.apply(value);
             if (customBlock.isPresent()) {
                 return Optional.of(customBlock.get());
             }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
@@ -1,12 +1,9 @@
 package world.bentobox.aoneblock.oneblocks;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
-
 import world.bentobox.aoneblock.oneblocks.customblock.BlockDataCustomBlock;
+
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * A creator for {@link OneBlockCustomBlock}
@@ -15,6 +12,7 @@ import world.bentobox.aoneblock.oneblocks.customblock.BlockDataCustomBlock;
  */
 public final class OneBlockCustomBlockCreator {
     private static final Map<String, Function<Map<?, ?>, Optional<? extends OneBlockCustomBlock>>> creatorMap = new LinkedHashMap<>();
+    private static final List<Function<String, Optional<? extends OneBlockCustomBlock>>> shortCreatorList = new ArrayList<>();
 
     static {
         register("block-data", BlockDataCustomBlock::fromMap);
@@ -35,6 +33,15 @@ public final class OneBlockCustomBlockCreator {
     }
 
     /**
+     * Register a short creator
+     *
+     * @param creator the creator
+     */
+    public static void register(Function<String, Optional<? extends OneBlockCustomBlock>> creator) {
+        shortCreatorList.add(creator);
+    }
+
+    /**
      * Create a custom block from the map
      *
      * @param map the map
@@ -46,5 +53,21 @@ public final class OneBlockCustomBlockCreator {
             return Optional.empty();
         }
         return Optional.ofNullable(creatorMap.get(type)).flatMap(builder -> builder.apply(map));
+    }
+
+    /**
+     * Create a custom block from the short type
+     *
+     * @param type the short type
+     * @return the custom block
+     */
+    public static Optional<OneBlockCustomBlock> create(String type) {
+        for (Function<String, Optional<? extends OneBlockCustomBlock>> creator : shortCreatorList) {
+            Optional<? extends OneBlockCustomBlock> customBlock = creator.apply(type);
+            if (customBlock.isPresent()) {
+                return Optional.of(customBlock.get());
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -396,9 +396,6 @@ public class OneBlocksManager {
     }
 
     void addBlocks(OneBlockPhase obPhase, ConfigurationSection phase) {
-        if (!phase.isConfigurationSection(BLOCKS)) {
-            return;
-        }
         if (phase.isConfigurationSection(BLOCKS)) {
             ConfigurationSection blocks = phase.getConfigurationSection(BLOCKS);
             for (String material : blocks.getKeys(false)) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -423,7 +423,6 @@ public class OneBlocksManager {
     }
 
     private boolean addMaterial(OneBlockPhase obPhase, String material, String probability) {
-        Material m = Material.matchMaterial(material);
         int prob;
         try {
             prob = Integer.parseInt(probability);
@@ -431,16 +430,26 @@ public class OneBlocksManager {
             return false;
         }
 
+        if (prob < 1) {
+            addon.logWarning("Bad item weight for " + obPhase.getPhaseName() + ": " + material + ". Must be positive number above 1.");
+            return false;
+        }
+
+        // Register if the material is a valid custom block and can be created from the short creator from OneBlockCustomBlockCreator
+        Optional<OneBlockCustomBlock> optionalCustomBlock = OneBlockCustomBlockCreator.create(material);
+        if (optionalCustomBlock.isPresent()) {
+            obPhase.addCustomBlock(optionalCustomBlock.get(), prob);
+            return true;
+        }
+
+        // Otherwise, register the material as a block
+        Material m = Material.matchMaterial(material);
         if (m == null || !m.isBlock()) {
             addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
             return false;
-        } else if (prob < 1) {
-            addon.logWarning("Bad item weight for " + obPhase.getPhaseName() + ": " + material + ". Must be positive number above 1.");
-            return false;
-        } else {
-            obPhase.addBlock(m, prob);
-            return true;
         }
+        obPhase.addBlock(m, prob);
+        return true;
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -230,7 +230,14 @@ public class OneBlocksManager {
                 }
             } else {
                 String mat = fb.getString(key);
-                if (mat != null) {
+                if (mat == null) {
+                    continue;
+                }
+
+                Optional<OneBlockCustomBlock> customBlock = OneBlockCustomBlockCreator.create(mat);
+                if (customBlock.isPresent()) {
+                    result.put(k, new OneBlockObject(customBlock.get(), 0));
+                } else {
                     Material m = Material.matchMaterial(mat);
                     if (m != null && m.isBlock()) {
                         result.put(k, new OneBlockObject(m, 0));

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
@@ -23,11 +23,11 @@ public class BlockDataCustomBlock implements OneBlockCustomBlock {
     }
 
     public static Optional<BlockDataCustomBlock> fromMap(Map<?, ?> map) {
-        if (map.containsKey("data")) {
-            return Optional.of(new BlockDataCustomBlock(Objects.toString(map.get("data"))));
-        } else {
+        String type = Objects.toString(map.get("data"), null);
+        if (type == null) {
             return Optional.empty();
         }
+        return Optional.of(new BlockDataCustomBlock(type));
     }
 
     @Override


### PR DESCRIPTION
This adds a check before Material to create `OneBlockCustomBlock` if the string is supported.

This enables developers to create their custom blocks from a single string (like #317), by creating their own `OneBlockCustomBlock` creator and register it as a "short creator".