### PR TITLE
ItemsAdder fix

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -88,8 +88,13 @@ public class AOneBlock extends GameModeAddon {
 
     @Override
     public void onEnable() {
-        loadData();
-
+        oneBlockManager = new OneBlocksManager(this);
+        if (loadData()) {
+            // Failed to load - don't register anything
+            return;
+        }
+        blockListener = new BlockListener(this);
+        registerListener(blockListener);
         registerListener(new NoBlockHandler(this));
         registerListener(new BlockProtect(this));
         registerListener(new JoinLeaveListener(this));
@@ -106,20 +111,18 @@ public class AOneBlock extends GameModeAddon {
         registerListener(holoListener);
     }
 
-    //Load some of Manager
-    public void loadData() {
+    // Load phase data
+    public boolean loadData() {
         try {
-            oneBlockManager = new OneBlocksManager(this);
             oneBlockManager.loadPhases();
-            blockListener = new BlockListener(this);
         } catch (IOException e) {
             // Disable
             logError("AOneBlock settings could not load (oneblock.yml error)! Addon disabled.");
             logError(e.getMessage());
             setState(State.DISABLED);
-            return;
+            return true;
         }
-        registerListener(blockListener);
+        return false;
     }
 
     private void registerPlaceholders() {

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -278,13 +278,7 @@ public class BlockListener implements Listener {
         String originalPhase = is.getPhaseName();
         // Check for a goto
         if (Objects.requireNonNull(phase).getGotoBlock() != null) {
-            int gotoBlock = phase.getGotoBlock();
-            phase = oneBlocksManager.getPhase(gotoBlock);
-            // Store lifetime
-            is.setLifetime(is.getLifetime() + gotoBlock);
-            // Set current block
-            is.setBlockNumber(gotoBlock);
-
+            handleGoto(is, phase);
         }
         // Check for new phase and run commands if required
         boolean newPhase = check.checkPhase(player, i, is, Objects.requireNonNull(phase));
@@ -353,6 +347,15 @@ public class BlockListener implements Listener {
         }
         // Increment the block number
         is.incrementBlockNumber();
+    }
+
+    private void handleGoto(OneBlockIslands is, OneBlockPhase phase) {
+        int gotoBlock = phase.getGotoBlock();
+        phase = oneBlocksManager.getPhase(gotoBlock);
+        // Store lifetime
+        is.setLifetime(is.getLifetime() + gotoBlock);
+        // Set current block
+        is.setBlockNumber(gotoBlock);
     }
 
     private void setBiome(@NonNull Block block, @Nullable Biome biome) {


### PR DESCRIPTION
The PR to add support for ItemsAdder created two block listeners that ran concurrently. This PR fixes that and only makes one instance of the objects.