### PR TITLE
Fixed issue causing plugin to sometimes throw an error when ItemsAdder is installed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>com.github.LoneDev6</groupId>
             <artifactId>API-ItemsAdder</artifactId>
-            <version>3.2.5</version>
+            <version>3.5.0b</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -404,46 +404,46 @@ public class BlockListener implements Listener {
     private void spawnBlock(@NonNull OneBlockObject nextBlock, @NonNull Block block) {
         if (nextBlock.isCustomBlock()) {
             nextBlock.getCustomBlock().setBlock(block);
-            return;
         } else if (nextBlock.isItemsAdderBlock()) {
             //Get Custom Block from ItemsAdder and place it
             CustomBlock cBlock = CustomBlock.getInstance(nextBlock.getItemsAdderBlock());
             if (cBlock != null) {
+                block.getLocation().getBlock().setType(Material.AIR);
                 cBlock.place(block.getLocation());
+            }
+        } else {
+            @NonNull
+            Material type = nextBlock.getMaterial();
+            // Place new block with no physics
+            block.setType(type, false);
+            // Fill the chest
+            if (type.equals(Material.CHEST) && nextBlock.getChest() != null) {
+                fillChest(nextBlock, block);
                 return;
+            } else if (Tag.LEAVES.isTagged(type)) {
+                Leaves leaves = (Leaves) block.getState().getBlockData();
+                leaves.setPersistent(true);
+                block.setBlockData(leaves);
+            } else if (block.getState() instanceof BrushableBlock bb) {
+                LootTable lt = switch(bb.getBlock().getBiome()) {
+                    default -> {
+                        if (random.nextDouble() < 0.8) {
+                            yield LootTables.TRAIL_RUINS_ARCHAEOLOGY_COMMON.getLootTable();
+                        } else {
+                            // 20% rare
+                            yield LootTables.TRAIL_RUINS_ARCHAEOLOGY_RARE.getLootTable();
+                        }
+                    }
+                    case DESERT -> LootTables.DESERT_PYRAMID_ARCHAEOLOGY.getLootTable();
+                    case FROZEN_OCEAN -> LootTables.OCEAN_RUIN_COLD_ARCHAEOLOGY.getLootTable();
+                    case OCEAN -> LootTables.OCEAN_RUIN_COLD_ARCHAEOLOGY.getLootTable();
+                    case WARM_OCEAN -> LootTables.OCEAN_RUIN_WARM_ARCHAEOLOGY.getLootTable();
+                };
+                bb.setLootTable(lt);
+                bb.update();
             }
         }
 
-        @NonNull
-        Material type = nextBlock.getMaterial();
-        // Place new block with no physics
-        block.setType(type, false);
-        // Fill the chest
-        if (type.equals(Material.CHEST) && nextBlock.getChest() != null) {
-            fillChest(nextBlock, block);
-            return;
-        } else if (Tag.LEAVES.isTagged(type)) {
-            Leaves leaves = (Leaves) block.getState().getBlockData();
-            leaves.setPersistent(true);
-            block.setBlockData(leaves);
-        } else if (block.getState() instanceof BrushableBlock bb) {
-            LootTable lt = switch(bb.getBlock().getBiome()) {
-            default -> {
-                if (random.nextDouble() < 0.8) {
-                    yield LootTables.TRAIL_RUINS_ARCHAEOLOGY_COMMON.getLootTable();
-                } else {
-                    // 20% rare
-                    yield LootTables.TRAIL_RUINS_ARCHAEOLOGY_RARE.getLootTable();
-                }
-            }
-            case DESERT -> LootTables.DESERT_PYRAMID_ARCHAEOLOGY.getLootTable();
-            case FROZEN_OCEAN -> LootTables.OCEAN_RUIN_COLD_ARCHAEOLOGY.getLootTable();
-            case OCEAN -> LootTables.OCEAN_RUIN_COLD_ARCHAEOLOGY.getLootTable();
-            case WARM_OCEAN -> LootTables.OCEAN_RUIN_WARM_ARCHAEOLOGY.getLootTable();
-            };
-            bb.setLootTable(lt);
-            bb.update();
-        }
     }
 
     private void spawnEntity(@NonNull OneBlockObject nextBlock, @NonNull Block block) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -415,8 +415,10 @@ public class OneBlocksManager {
                         CustomBlock block = CustomBlock.getInstance(material);
                         if (block != null) {
                             addItemsAdderBlock(obPhase, material, Objects.toString(blocks.get(material)));
-                        } else if (ItemsAdder.getAllItems().size() != 0){
-                            addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
+                        } else if (ItemsAdder.getAllItems() != null){
+                            if (ItemsAdder.getAllItems().size() != 0) {
+                                addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
+                            }
                         }
                     } else {
                         addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);


### PR DESCRIPTION
This PR fixes the issue where the plugin will sometimes throws an error if ItemsAdder is installed because `ItemsAdder.getAllItems()` returns null. 
This PR also update the ItemsAdder API from 3.2.5 to 3.5.0b.