### PR TITLE
Bug fixes & CustomBlock type for mob spawning

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -172,6 +172,7 @@ public class AOneBlock extends GameModeAddon {
 		blockListener.saveCache();
 		if (loadSettings()) {
 			log("Reloaded AOneBlock settings");
+			loadData();
 		}
 	}
 

--- a/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
+++ b/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
@@ -44,6 +44,12 @@ public class OneBlockIslands implements DataObject {
     @Expose
     private String hologram = "";
 
+    /**
+     * Timestamp of last phase change
+     */
+    @Expose
+    private long lastPhaseChangeTime = 0;
+
     private Queue<OneBlockObject> queue = new LinkedList<>();
 
     /**
@@ -196,5 +202,17 @@ public class OneBlockIslands implements DataObject {
         this.lifetime = lifetime;
     }
 
+    /**
+     * @return Timestamp of last phase change
+     */
+    public long getLastPhaseChangeTime() {
+        return this.lastPhaseChangeTime;
+    }
 
+    /**
+     * @param lastPhaseChangeTime Timestamp of last phase change
+     */
+    public void setLastPhaseChangeTime(long lastPhaseChangeTime) {
+        this.lastPhaseChangeTime = lastPhaseChangeTime;
+    }
 }

--- a/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
+++ b/src/main/java/world/bentobox/aoneblock/dataobjects/OneBlockIslands.java
@@ -10,6 +10,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import com.google.gson.annotations.Expose;
 
 import world.bentobox.aoneblock.oneblocks.OneBlockObject;
+import world.bentobox.aoneblock.oneblocks.customblock.MobCustomBlock;
 import world.bentobox.bentobox.database.objects.DataObject;
 import world.bentobox.bentobox.database.objects.Table;
 
@@ -135,7 +136,16 @@ public class OneBlockIslands implements DataObject {
      * @return list of upcoming mobs
      */
     public List<EntityType> getNearestMob(int i) {
-        return getQueue().stream().limit(i).filter(OneBlockObject::isEntity).map(OneBlockObject::getEntityType).toList();
+        return getQueue().stream().limit(i).filter(obo ->
+                // Include OneBlockObjects that are Entity, or custom block of type MobCustomBlock
+                obo.isEntity() || (obo.isCustomBlock() && obo.getCustomBlock() instanceof MobCustomBlock)
+        ).map(obo -> {
+            if (obo.isCustomBlock() && obo.getCustomBlock() instanceof MobCustomBlock) {
+                return ((MobCustomBlock) obo.getCustomBlock()).getMob();
+            }
+
+            return obo.getEntityType();
+        }).toList();
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -295,7 +295,8 @@ public class BlockListener implements Listener {
             is.clearQueue();
         }
         // Get the block number in this phase
-        int blockNumber = is.getBlockNumber() - phase.getBlockNumberValue() + (int) is.getQueue().stream().filter(OneBlockObject::isMaterial).count();
+        int materialBlocksInQueue = (int) is.getQueue().stream().filter(obo -> obo.isMaterial() || obo.isCustomBlock()).count();
+        int blockNumber = is.getBlockNumber() - (phase.getBlockNumberValue() - 1) + materialBlocksInQueue;
         // Get the block that is being broken
         Block block = Objects.requireNonNull(i.getCenter()).toVector().toLocation(world).getBlock();
         // Fill a 5 block queue
@@ -406,7 +407,7 @@ public class BlockListener implements Listener {
 
     private void spawnBlock(@NonNull OneBlockObject nextBlock, @NonNull Block block) {
         if (nextBlock.isCustomBlock()) {
-            nextBlock.getCustomBlock().setBlock(block);
+            nextBlock.getCustomBlock().execute(addon, block);
         } else if (nextBlock.isItemsAdderBlock()) {
             //Get Custom Block from ItemsAdder and place it
             CustomBlock cBlock = CustomBlock.getInstance(nextBlock.getItemsAdderBlock());

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -287,12 +287,13 @@ public class BlockListener implements Listener {
             saveIsland(i);
         }
         // Check if requirements met
-        if (check.phaseRequirementsFail(player, i, phase, world)) {
+        if (check.phaseRequirementsFail(player, i, is, phase, world)) {
             e.setCancelled(true);
             return;
         }
         if (newPhase) {
             is.clearQueue();
+            is.setLastPhaseChangeTime(System.currentTimeMillis());
         }
         // Get the block number in this phase
         int materialBlocksInQueue = (int) is.getQueue().stream().filter(obo -> obo.isMaterial() || obo.isCustomBlock()).count();

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -52,7 +52,7 @@ public class CheckPhase {
      * @param world  - world
      * @return true if the player cannot proceed to the next phase.
      */
-    protected boolean phaseRequirementsFail(@Nullable Player player, @NonNull Island i, OneBlockPhase phase, @NonNull World world) {
+    protected boolean phaseRequirementsFail(@Nullable Player player, @NonNull Island i, @NonNull OneBlockIslands is, OneBlockPhase phase, @NonNull World world) {
         if (phase.getRequirements().isEmpty()) {
             return false;
         }
@@ -84,6 +84,14 @@ public class CheckPhase {
             case PERMISSION -> {
                 if (player != null && !player.hasPermission(r.getPermission())) {
                     User.getInstance(player).sendMessage("aoneblock.phase.insufficient-permission", TextVariables.NAME, String.valueOf(r.getPermission()));
+                    yield true;
+                }
+                yield false;
+            }
+            case COOLDOWN -> {
+                long remainingTime = r.getCooldown() - (System.currentTimeMillis() - is.getLastPhaseChangeTime()) / 1000;
+                if(remainingTime > 0){
+                    User.getInstance(player).sendMessage("aoneblock.phase.cooldown", TextVariables.NUMBER, String.valueOf(remainingTime));
                     yield true;
                 }
                 yield false;

--- a/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
@@ -52,7 +52,7 @@ public class MakeSpace {
      * @param entity Entity that is spawned.
      * @param spawnLocation Location where entity is spawned.
      */
-    void makeSpace(@NonNull Entity entity, @NonNull Location spawnLocation)
+    public void makeSpace(@NonNull Entity entity, @NonNull Location spawnLocation)
     {
         World world = entity.getWorld();
         List<Block> airBlocks = new ArrayList<>();

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlock.java
@@ -1,17 +1,18 @@
 package world.bentobox.aoneblock.oneblocks;
 
 import org.bukkit.block.Block;
+import world.bentobox.aoneblock.AOneBlock;
 
 /**
- * Represents a custom block
+ * Represents a custom block with custom executable
  *
  * @author HSGamer
  */
 public interface OneBlockCustomBlock {
     /**
-     * Set the block
+     * Executes the custom logic
      *
      * @param block the block
      */
-    void setBlock(Block block);
+    void execute(AOneBlock addon, Block block);
 }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockCustomBlockCreator.java
@@ -1,6 +1,7 @@
 package world.bentobox.aoneblock.oneblocks;
 
 import world.bentobox.aoneblock.oneblocks.customblock.BlockDataCustomBlock;
+import world.bentobox.aoneblock.oneblocks.customblock.MobCustomBlock;
 
 import java.util.*;
 import java.util.function.Function;
@@ -16,6 +17,7 @@ public final class OneBlockCustomBlockCreator {
 
     static {
         register("block-data", BlockDataCustomBlock::fromMap);
+        register("mob", MobCustomBlock::fromMap);
         register("short", map -> {
             String type = Objects.toString(map.get("data"), null);
             if (type == null) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/Requirement.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/Requirement.java
@@ -26,7 +26,11 @@ public record Requirement(ReqType type, Object requirement) {
         /**
          * Permission
          */
-        PERMISSION("permission", String.class);
+        PERMISSION("permission", String.class),
+        /**
+         * Cooldown
+         */
+        COOLDOWN("cooldown", Long.class);
 
         private final String key;
         private final Class<?> clazz;
@@ -77,6 +81,13 @@ public record Requirement(ReqType type, Object requirement) {
      */
     public String getPermission() {
         return (String)requirement;
+    }
+
+    /**
+     * @return the cooldown
+     */
+    public long getCooldown() {
+        return (long)requirement;
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 
+import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
 import world.bentobox.bentobox.BentoBox;
 
@@ -31,7 +32,7 @@ public class BlockDataCustomBlock implements OneBlockCustomBlock {
     }
 
     @Override
-    public void setBlock(Block block) {
+    public void execute(AOneBlock addon, Block block) {
         try {
             block.setBlockData(Bukkit.createBlockData(blockData));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
@@ -1,0 +1,96 @@
+package world.bentobox.aoneblock.oneblocks.customblock;
+
+import com.google.common.base.Enums;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.util.Vector;
+import org.eclipse.jdt.annotation.NonNull;
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.listeners.MakeSpace;
+import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
+import world.bentobox.bentobox.BentoBox;
+
+import java.util.*;
+
+/**
+ * A custom block that spawns mob on an underlying block
+ *
+ * @author HSGamer
+ */
+public class MobCustomBlock implements OneBlockCustomBlock {
+    private final EntityType mob;
+    private final Material underlyingBlock;
+
+    public MobCustomBlock(EntityType mob, Material underlyingBlock) {
+        this.mob = mob;
+        this.underlyingBlock = underlyingBlock;
+    }
+
+    public static Optional<MobCustomBlock> fromMap(Map<?, ?> map) {
+        String entityTypeValue = Objects.toString(map.get("mob"), null);
+        String underlyingBlockValue = Objects.toString(map.get("underlying-block"), null);
+
+        EntityType entityType = maybeEntity(entityTypeValue);
+        Material underlyingBlock = Material.getMaterial(underlyingBlockValue);
+
+        if(underlyingBlock == null){
+            BentoBox.getInstance().logWarning("Underlying block " + underlyingBlockValue + " does not exist and will be replaced with STONE.");
+        }
+
+        return Optional.of(new MobCustomBlock(entityType, underlyingBlock));
+    }
+
+    private static EntityType maybeEntity(String entityTypeValue) {
+        String name = entityTypeValue.toUpperCase(Locale.ENGLISH);
+        EntityType et;
+
+        // Pig zombie handling
+        if (name.equals("PIG_ZOMBIE") || name.equals("ZOMBIFIED_PIGLIN")) {
+            et = Enums.getIfPresent(EntityType.class, "ZOMBIFIED_PIGLIN")
+                    .or(Enums.getIfPresent(EntityType.class, "PIG_ZOMBIE").or(EntityType.PIG));
+        } else {
+            et = Enums.getIfPresent(EntityType.class, name).orNull();
+        }
+
+        if (et == null) {
+            // Does not exist
+            BentoBox.getInstance().logWarning("Entity " + name + " does not exist and will not spawn when block is shown.");
+            return null;
+        }
+        if (et.isSpawnable() && et.isAlive()) {
+            return et;
+        } else {
+            // Not spawnable
+            BentoBox.getInstance().logWarning("Entity " + et.name() + " is not spawnable and will not spawn when block is shown.");
+            return null;
+        }
+    }
+
+    @Override
+    public void execute(AOneBlock addon, Block block) {
+        try {
+            block.setType(Objects.requireNonNullElse(underlyingBlock, Material.STONE));
+            spawnEntity(addon, block, mob);
+        } catch (Exception e) {
+            BentoBox.getInstance().logError("Could not spawn entity " + mob.name() + " on block " + block.getType());
+        }
+    }
+
+    private void spawnEntity(AOneBlock addon, @NonNull Block block, @NonNull EntityType mob) {
+        Location spawnLoc = block.getLocation().add(new Vector(0.5D, 1D, 0.5D));
+        Entity entity = block.getWorld().spawnEntity(spawnLoc, mob);
+        // Make space for entity - this will blot out blocks
+        if (addon.getSettings().isClearBlocks()) {
+            new MakeSpace(addon).makeSpace(entity, spawnLoc);
+        }
+        block.getWorld().playSound(block.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1F, 2F);
+    }
+
+    public EntityType getMob() {
+        return mob;
+    }
+}

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
@@ -19,7 +19,7 @@ import java.util.*;
 /**
  * A custom block that spawns mob on an underlying block
  *
- * @author HSGamer
+ * @author Baterka
  */
 public class MobCustomBlock implements OneBlockCustomBlock {
     private final EntityType mob;

--- a/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
+++ b/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
@@ -453,7 +453,7 @@ public class PhasesPanel
             if (phase.getBlockNumberValue() < lifetime)
             {
                 // Check if phase requirements are met.
-                canApply = !this.phaseRequirementsFail(phase);
+                canApply = !this.phaseRequirementsFail(phase, this.oneBlockIsland);
             }
             else
             {
@@ -521,7 +521,7 @@ public class PhasesPanel
      * @param phase Phase object.
      * @return {@code true} if phase requirements fails, {@code false} otherwise.
      */
-    private boolean phaseRequirementsFail(OneBlockPhase phase)
+    private boolean phaseRequirementsFail(OneBlockPhase phase, OneBlockIslands is)
     {
         // Check requirements
         for (Requirement requirement : phase.getRequirements())
@@ -537,6 +537,8 @@ public class PhasesPanel
             case ECO -> this.addon.getPlugin().getVault().map(a -> a.getBalance(this.user, this.world) < requirement.getEco()).orElse(false);
 
             case PERMISSION -> this.user != null && !this.user.hasPermission(requirement.getPermission());
+
+            case COOLDOWN -> (requirement.getCooldown() - (System.currentTimeMillis() - is.getLastPhaseChangeTime()) / 1000) > 0;
             }) {
                 return true;
             }

--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -48,7 +48,8 @@ aoneblock:
     insufficient-funds: Nemáš dostatečné prostředky! Musíš mít alespoň [number].
     insufficient-bank-balance: V Bance ostrova není dostatek financí! Je potřeba alespoň
       [number].
-    insufficient-permission: "&c Nemůžete pokračovat, dokud nezískáte oprávnění [jméno]!"
+    insufficient-permission: "&c Nemůžete pokračovat, dokud nezískáte oprávnění [name]!"
+    cooldown: "&c Další fáze bude dostupná za [number] sekund!"
   placeholders:
     infinite: Nekonečný
   gui:

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -58,6 +58,7 @@ aoneblock:
       Es muss [number] sein."
     insufficient-permission: "&c Sie können nicht weitermachen, bis Sie die [name]-Berechtigung
       erhalten!"
+    cooldown: "&c Die nächste Stufe ist in [number] Sekunden verfügbar!"
   placeholders:
     infinite: Unendlich
   gui:

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -50,6 +50,7 @@ aoneblock:
     insufficient-funds: "&c Your funds are too low to proceed! They must be [number]."
     insufficient-bank-balance: "&c The island bank balance is too low to proceed! It must be [number]."
     insufficient-permission: "&c You can proceed no further until you obtain the [name] permission!"
+    cooldown: "&c Next phase will be available in [number] seconds!"
   placeholders:
     infinite: Infinite
   gui:

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -53,6 +53,7 @@ aoneblock:
       para seguir! Debes tener [number]."
     insufficient-permission: "&c ¡No puede continuar hasta que obtenga el permiso
       de [name]!"
+    cooldown: "&c ¡La siguiente etapa estará disponible en [number] segundos!"
   placeholders:
     infinite: Infinito
   gui:

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -54,6 +54,7 @@ aoneblock:
       devez au moins avoir [number].
     insufficient-permission: "&c Vous ne pouvez pas continuer jusqu'à ce que vous
       obteniez l'autorisation de [name] !"
+    cooldown: "&c La prochaine étape sera disponible dans [number] secondes!"
   placeholders:
     infinite: Infini
   gui:

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -50,6 +50,7 @@ aoneblock:
     insufficient-bank-balance: "&c Stanje otočne banke je premalo za nastavak! Mora
       biti [number]."
     insufficient-permission: "&c Ne možete nastaviti dok ne dobijete dopuštenje [name]!"
+    cooldown: "&c Sljedeća faza bit će dostupna za [number] sekundi!"
   placeholders:
     infinite: Beskonačno
   gui:

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -55,6 +55,7 @@ aoneblock:
       Ennek a következőnek kell lennie: [number]."
     insufficient-permission: "&c Nem folytathatja tovább, amíg meg nem szerzi a [name]
       engedélyt!"
+    cooldown: "&c A következő szakasz [number] másodpercen belül elérhető lesz!"
   placeholders:
     infinite: Végtelen
   gui:

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -47,6 +47,7 @@ aoneblock:
     insufficient-funds: "&c 資金が少なすぎるため続行できません。 [number] である必要があります。"
     insufficient-bank-balance: "&c 島の銀行残高が少なすぎるため続行できません。 [number] である必要があります。"
     insufficient-permission: "&c [name] の許可を取得するまで、これ以上先に進むことはできません。"
+    cooldown: "&c [number] 秒で次のステージへ!"
   placeholders:
     infinite: 無限
   gui:

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -48,6 +48,7 @@ aoneblock:
       aby kontynuować! Musi to być [number].
     insufficient-permission: Nie możesz kontynuować, dopóki nie uzyskasz pozwolenia
       [name]!
+    cooldown: "&c Następny etap będzie dostępny za [number] sekund!"
   placeholders:
     infinite: Nieskończony
   gui:

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -51,6 +51,7 @@ aoneblock:
       Должно быть [number]."
     insufficient-permission: "&c Вы не можете продолжать, пока не получите разрешение
       [name]!"
+    cooldown: "&c Следующий этап будет доступен через [number] секунд!"
   placeholders:
     infinite: Бесконечный
   gui:

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -43,6 +43,7 @@ aoneblock:
     insufficient-bank-balance: "&c Ada bankası bakiyesi devam etmek için çok düşük!
       [number] olmalıdır."
     insufficient-permission: "&c [name] iznini alana kadar devam edemezsiniz!"
+    cooldown: "&c Bir sonraki aşama [number] saniye içinde hazır olacak!"
   placeholders:
     infinite: Sonsuz
   island:

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -44,6 +44,7 @@ aoneblock:
     insufficient-bank-balance: Ngân hàng đảo của bạn quá thấp để thực thi! Nó phải
       là [number].
     insufficient-permission: Bạn không thể thực thi tiếp cho đến khi có quyền [name]!
+    cooldown: Giai đoạn tiếp theo sẽ có sau [number] giây!
   placeholders:
     infinite: Vô hạn
   island:

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -46,6 +46,7 @@ aoneblock:
     insufficient-funds: "&c 余额不足, 无法执行此操作! 余额应多于 [number]."
     insufficient-bank-balance: "&c 岛屿银行余额不足, 无法执行此操作! 余额应多于 [number]."
     insufficient-permission: "&c 在获得 [name] 许可之前，您不能继续操作！"
+    cooldown: "&c [number] 秒后即可进入下一阶段！"
   placeholders:
     infinite: 无限
   gui:

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -46,6 +46,7 @@ aoneblock:
     insufficient-funds: "&c 您的資金太低，無法繼續！他們必須是[數字]。"
     insufficient-bank-balance: "&c 島上銀行餘額太低，無法繼續！必須是[number]。"
     insufficient-permission: "&c 在獲得 [name] 許可之前，您不能繼續操作！"
+    cooldown: "&c [number] 秒後即可進入下一階段！"
   placeholders:
     infinite: 無窮
   gui:

--- a/src/main/resources/phases/0_plains.yml
+++ b/src/main/resources/phases/0_plains.yml
@@ -56,6 +56,7 @@
   #   bank-balance: 10000
   #   level: 10
   #   permission: ready.for.battle
+  #   cooldown: 60
   
   blocks:
     PODZOL: 40


### PR DESCRIPTION
Fixes:
 - Everytime new phase was set, plugin sent the first block of the phase 2 times.
 - CustomBlocks in fixedBlocks were causing issues where it was pushing the CustomBlock multiple times into queue.
 - Phase config was not refreshed when doing /isa reload. I tested it and I do not see any issues.

Refactors:
 - Variable naming refactors, because having name `obPhase` for `phase` instance + name `phase` for the `ConfigurationSection` was not really understandable (I changed it to `phaseConfig`)

Added features:
 - New `CustomBlock` for mobs in format:
 - `type: mob mob: ZOMBIE underlying-block: GRASS_BLOCK`  It will spawn a mob on top of underlying block. I know that mob spawns are not exactly counted as "destroyed block", but in this case it is needed. It would not make sense setting it in fixedBlocks if not.
 - New `Requirement - cooldown` (seconds) that blocks new phase until time elapses.