### PR TITLE
Let ItemsAdder be a new OneBlockCustomBlock

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlock.java
@@ -24,7 +24,9 @@ import world.bentobox.aoneblock.listeners.InfoListener;
 import world.bentobox.aoneblock.listeners.ItemsAdderListener;
 import world.bentobox.aoneblock.listeners.JoinLeaveListener;
 import world.bentobox.aoneblock.listeners.NoBlockHandler;
+import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlockCreator;
 import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
+import world.bentobox.aoneblock.oneblocks.customblock.ItemsAdderCustomBlock;
 import world.bentobox.aoneblock.requests.IslandStatsHandler;
 import world.bentobox.aoneblock.requests.LocationStatsHandler;
 import world.bentobox.bentobox.api.addons.GameModeAddon;
@@ -57,6 +59,8 @@ public class AOneBlock extends GameModeAddon {
 		// Check if ItemsAdder exists, if yes register listener
 		if (Bukkit.getPluginManager().getPlugin("ItemsAdder") != null) {
 			registerListener(new ItemsAdderListener(this));
+			OneBlockCustomBlockCreator.register(ItemsAdderCustomBlock::fromId);
+			OneBlockCustomBlockCreator.register("itemsadder", ItemsAdderCustomBlock::fromMap);
 			hasItemsAdder = true;
 		}
 		// Save the default config from config.yml

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -41,7 +41,6 @@ import org.bukkit.util.Vector;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 
-import dev.lone.itemsadder.api.CustomBlock;
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.events.MagicBlockEntityEvent;
@@ -409,13 +408,6 @@ public class BlockListener implements Listener {
     private void spawnBlock(@NonNull OneBlockObject nextBlock, @NonNull Block block) {
         if (nextBlock.isCustomBlock()) {
             nextBlock.getCustomBlock().execute(addon, block);
-        } else if (nextBlock.isItemsAdderBlock()) {
-            //Get Custom Block from ItemsAdder and place it
-            CustomBlock cBlock = CustomBlock.getInstance(nextBlock.getItemsAdderBlock());
-            if (cBlock != null) {
-                block.getLocation().getBlock().setType(Material.AIR);
-                cBlock.place(block.getLocation());
-            }
         } else {
             @NonNull
             Material type = nextBlock.getMaterial();

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockObject.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockObject.java
@@ -42,7 +42,6 @@ public class OneBlockObject {
     private Map<Integer, ItemStack> chest;
     private Rarity rarity;
     private OneBlockCustomBlock customBlock;
-    private String itemsAdderBlock;
     private int prob;
 
     /**
@@ -79,18 +78,6 @@ public class OneBlockObject {
     }
 
     /**
-     * An ItemsAdder block
-     *
-     * @param namedSpaceID - ItemsAdder block
-     * @param prob        - relative probability
-     */
-
-    public OneBlockObject(String namedSpaceID, int prob) {
-        this.itemsAdderBlock = namedSpaceID;
-        this.prob = prob;
-    }
-
-    /**
      * A chest
      *
      * @param chest - list of itemstacks in the chest
@@ -113,7 +100,6 @@ public class OneBlockObject {
         this.rarity = ob.getRarity();
         this.prob = ob.getProb();
         this.customBlock = ob.getCustomBlock();
-        this.itemsAdderBlock = ob.getItemsAdderBlock();
     }
 
     /**
@@ -147,11 +133,6 @@ public class OneBlockObject {
         return customBlock;
     }
 
-    /**
-     * @return the itemsAdderBlock
-     */
-    public String getItemsAdderBlock() { return itemsAdderBlock; }
-
 
     /**
      * @return the isMaterial
@@ -174,13 +155,6 @@ public class OneBlockObject {
      */
     public boolean isCustomBlock() {
         return customBlock != null;
-    }
-
-    /**
-     * @return the isItemsAdderBlock
-     */
-    public boolean isItemsAdderBlock() {
-        return itemsAdderBlock != null;
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -166,17 +166,6 @@ public class OneBlockPhase {
     }
 
     /**
-     * Adds a ItemsAdder's custom block and associated probability
-     * @param namedSpaceID - name space and ID
-     * @param prob        - probability
-     */
-    public void addItemsAdderCustomBlock(String namedSpaceID, int prob) {
-        total += prob;
-        blockTotal += prob;
-        probMap.put(total, new OneBlockObject(namedSpaceID, prob));
-    }
-
-    /**
      * Adds an entity type and associated probability
      *
      * @param entityType - entityType

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -487,22 +487,7 @@ public class OneBlocksManager {
 	if (phase.isConfigurationSection(BLOCKS)) {
 	    ConfigurationSection blocks = phase.getConfigurationSection(BLOCKS);
 	    for (String material : blocks.getKeys(false)) {
-		if (Material.getMaterial(material) != null) {
-		    addMaterial(obPhase, material, Objects.toString(blocks.get(material)));
-		} else {
-		    if (addon.hasItemsAdder()) {
-			CustomBlock block = CustomBlock.getInstance(material);
-			if (block != null) {
-			    addItemsAdderBlock(obPhase, material, Objects.toString(blocks.get(material)));
-			} else if (ItemsAdder.getAllItems() != null) {
-			    if (ItemsAdder.getAllItems().size() != 0) {
-				addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
-			    }
-			}
-		    } else {
-			addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
-		    }
-		}
+			addMaterial(obPhase, material, Objects.toString(blocks.get(material)));
 	    }
 	} else if (phase.isList(BLOCKS)) {
 	    List<Map<?, ?>> blocks = phase.getMapList(BLOCKS);
@@ -555,22 +540,6 @@ public class OneBlocksManager {
 	}
 	obPhase.addBlock(m, prob);
 	return true;
-    }
-
-    private void addItemsAdderBlock(OneBlockPhase obPhase, String block, String probability) {
-	int prob;
-	try {
-	    prob = Integer.parseInt(probability);
-	    if (prob < 1) {
-		addon.logWarning("Bad item weight for " + obPhase.getPhaseName() + ": " + block
-			+ ". Must be positive number above 1.");
-	    } else {
-		obPhase.addItemsAdderCustomBlock(block, prob);
-	    }
-	} catch (Exception e) {
-	    addon.logError("Bad item weight for " + obPhase.getPhaseName() + ": " + block + ". Must be a number.");
-	}
-
     }
 
     /**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -31,8 +31,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.google.common.base.Enums;
 import com.google.common.io.Files;
 
-import dev.lone.itemsadder.api.CustomBlock;
-import dev.lone.itemsadder.api.ItemsAdder;
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.oneblocks.OneBlockObject.Rarity;
@@ -444,22 +442,7 @@ public class OneBlocksManager {
 		if (phase.isConfigurationSection(BLOCKS)) {
 			ConfigurationSection blocks = phase.getConfigurationSection(BLOCKS);
 			for (String material : blocks.getKeys(false)) {
-				if (Material.getMaterial(material) != null) {
-					addMaterial(obPhase, material, Objects.toString(blocks.get(material)));
-				} else {
-					if (addon.hasItemsAdder()) {
-						CustomBlock block = CustomBlock.getInstance(material);
-						if (block != null) {
-							addItemsAdderBlock(obPhase, material, Objects.toString(blocks.get(material)));
-						} else if (ItemsAdder.getAllItems() != null) {
-							if (ItemsAdder.getAllItems().size() != 0) {
-								addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
-							}
-						}
-					} else {
-						addon.logError("Bad block material in " + obPhase.getPhaseName() + ": " + material);
-					}
-				}
+				addMaterial(obPhase, material, Objects.toString(blocks.get(material)));
 			}
 		} else if (phase.isList(BLOCKS)) {
 			List<Map<?, ?>> blocks = phase.getMapList(BLOCKS);
@@ -512,22 +495,6 @@ public class OneBlocksManager {
 		}
 		obPhase.addBlock(m, prob);
 		return true;
-	}
-
-	private void addItemsAdderBlock(OneBlockPhase obPhase, String block, String probability) {
-		int prob;
-		try {
-			prob = Integer.parseInt(probability);
-			if (prob < 1) {
-				addon.logWarning("Bad item weight for " + obPhase.getPhaseName() + ": " + block
-						+ ". Must be positive number above 1.");
-			} else {
-				obPhase.addItemsAdderCustomBlock(block, prob);
-			}
-		} catch (Exception e) {
-			addon.logError("Bad item weight for " + obPhase.getPhaseName() + ": " + block + ". Must be a number.");
-		}
-
 	}
 
 	/**

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/BlockDataCustomBlock.java
@@ -1,15 +1,14 @@
 package world.bentobox.aoneblock.oneblocks.customblock;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
-
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
 import world.bentobox.bentobox.BentoBox;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A custom block that is defined by a block data value.

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/ItemsAdderCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/ItemsAdderCustomBlock.java
@@ -1,0 +1,41 @@
+package world.bentobox.aoneblock.oneblocks.customblock;
+
+import dev.lone.itemsadder.api.CustomBlock;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
+import world.bentobox.bentobox.BentoBox;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class ItemsAdderCustomBlock implements OneBlockCustomBlock {
+    private final CustomBlock customBlock;
+
+    public ItemsAdderCustomBlock(CustomBlock customBlock) {
+        this.customBlock = customBlock;
+    }
+
+    public static Optional<ItemsAdderCustomBlock> fromId(String id) {
+        return Optional.ofNullable(CustomBlock.getInstance(id)).map(ItemsAdderCustomBlock::new);
+    }
+
+    public static Optional<ItemsAdderCustomBlock> fromMap(Map<?, ?> map) {
+        return Optional
+                .ofNullable(Objects.toString(map.get("id"), null))
+                .flatMap(ItemsAdderCustomBlock::fromId);
+    }
+
+    @Override
+    public void execute(AOneBlock addon, Block block) {
+        try {
+            block.setType(Material.AIR);
+            customBlock.place(block.getLocation());
+        } catch (Exception e) {
+            BentoBox.getInstance().logError("Could not place custom block " + customBlock.getId() + " for block " + block.getType());
+            block.setType(Material.STONE);
+        }
+    }
+}

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MobCustomBlock.java
@@ -14,7 +14,10 @@ import world.bentobox.aoneblock.listeners.MakeSpace;
 import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
 import world.bentobox.bentobox.BentoBox;
 
-import java.util.*;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A custom block that spawns mob on an underlying block
@@ -37,7 +40,7 @@ public class MobCustomBlock implements OneBlockCustomBlock {
         EntityType entityType = maybeEntity(entityTypeValue);
         Material underlyingBlock = Material.getMaterial(underlyingBlockValue);
 
-        if(underlyingBlock == null){
+        if (underlyingBlock == null) {
             BentoBox.getInstance().logWarning("Underlying block " + underlyingBlockValue + " does not exist and will be replaced with STONE.");
         }
 


### PR DESCRIPTION
This moved the ItemsAdder to a new `OneBlockCustomBlock`.

It bugs me that ItemsAdder is treated differently, although we already have `CustomBlock`. So this is to prove a point that something that supports ItemsAdder can be either a new `CustomBlock` or a new Addon.

P/S: Should I just remove the ItemsAdder code and create a new Addon, or just make a new `CustomBlock`?