### PR TITLE
Fix for null players, i.e., minions at end of phase.

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -108,6 +108,10 @@ public class CheckPhase {
 	    return false;
 	}
 
+    if (player == null) {
+        // Minions cannot fulfill requirements
+        return true;
+    }
 	return phase.getRequirements().stream()
 		.anyMatch(r -> checkRequirement(r, User.getInstance(player), i, is, world));
     }
@@ -206,7 +210,8 @@ public class CheckPhase {
 		    .map(l -> ((Level) l).getIslandLevel(addon.getOverWorld(), i.getOwner())).orElse(0L);
 	    double balance = addon.getAddonByName("Bank").map(b -> ((Bank) b).getBankManager().getBalance(i).getValue())
 		    .orElse(0D);
-	    double ecoBalance = addon.getPlugin().getVault()
+        double ecoBalance = player == null ? 0D
+                : addon.getPlugin().getVault()
 		    .map(v -> v.getBalance(User.getInstance(player), addon.getOverWorld())).orElse(0D);
 
 	    return c.replace("[island]", i.getName() == null ? "" : i.getName())


### PR DESCRIPTION
If a minion broke the block at the end of the phase, the NPEs would occur as the newer code to check requirements and do placeholders was assuming a real player. This change protects that. Note that minions cannot be used to progress past a phase if there are any restrictions on the level change.

Fixes #389 