### PR TITLE
Spawn custom-blocks bosses and spawners on the current tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ blocks:
   # `setblock <x> <y> <z>`. Use single quotes around the data so any
   # double quotes inside the NBT don't clash with YAML string delimiters.
   - type: block
-    data: 'spawner{Delay:20,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
+    data: 'spawner{Delay:0,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
     probability: 10
 
   # #488: summon an entity with vanilla NBT/component data, same syntax as /summon.
@@ -237,8 +237,10 @@ setblock mode flag so the intent is obvious at a glance.
 > **inactive** (`Delay:-1` means "never tick"). If you want it to actually spawn
 > mobs, set `Delay`, `MinSpawnDelay`, `MaxSpawnDelay`, `SpawnCount`, `SpawnRange`,
 > `MaxNearbyEntities`, and `RequiredPlayerRange` explicitly, as shown in the
-> example above. Test your full data string in-game with `/setblock ~ ~ ~ <data>`
-> first — if the spawner ticks there, it will tick from `custom-blocks:` too.
+> example above. `Delay:0` spawns on the very next tick (visually instant),
+> `Delay:N` waits N ticks before the first spawn, and `Delay:-1` never ticks.
+> Test your full data string in-game with `/setblock ~ ~ ~ <data>` first — if
+> the spawner ticks there, it will tick from `custom-blocks:` too.
 
 > **Note:** the `mob-data` string is passed straight to the vanilla `/summon`
 > command, so it must be valid NBT for your server version. A few 1.21 gotchas:
@@ -267,7 +269,7 @@ custom-blocks:
     probability: 50
 
   - type: block
-    data: 'spawner{Delay:20,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
+    data: 'spawner{Delay:0,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
     probability: 10
 
   - type: mythic-mob

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MythicMobCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/MythicMobCustomBlock.java
@@ -126,8 +126,12 @@ public class MythicMobCustomBlock implements OneBlockCustomBlock {
                 }
             };
 
-            // Prefer the 3-arg overload (BentoBox >= 3.14.0) so MakeSpace can run after
-            // the 40-tick spawn delay. Fall back to the 2-arg method on older BentoBox.
+            // Prefer the 4-arg overload (BentoBox >= 3.15.0) with delayTicks=0 so the
+            // boss appears on the current tick instead of after the hook's historical
+            // 40-tick delay — that delay exists for blueprint-paste callers and is
+            // unnecessary for AOneBlock's synchronous block replace. Fall back to the
+            // 3-arg overload (BentoBox >= 3.14.0, 40-tick delay) and finally the 2-arg
+            // method on older BentoBox. MakeSpace still runs from the callback.
             if (!invokeWithCallback(hook, record, spawnLoc, onSpawn)) {
                 hook.spawnMythicMob(record, spawnLoc);
             }
@@ -139,14 +143,36 @@ public class MythicMobCustomBlock implements OneBlockCustomBlock {
     }
 
     /**
-     * Attempts to call the 3-arg {@code spawnMythicMob(record, location, Consumer)}
-     * via reflection so this class still compiles and runs against BentoBox versions
-     * that don't yet ship the callback overload.
+     * Attempts to call the MythicMobsHook overload with a {@code Consumer<Entity>}
+     * callback via reflection so this class still compiles and runs against
+     * BentoBox versions that don't yet ship the overload.
+     * <p>
+     * Tries the 4-arg {@code spawnMythicMob(record, location, Consumer, long)}
+     * form first with {@code delayTicks=0} so the boss spawns on the current
+     * tick (BentoBox >= 3.15.0). If that isn't available, falls back to the
+     * 3-arg {@code spawnMythicMob(record, location, Consumer)} form with its
+     * built-in 40-tick delay (BentoBox >= 3.14.0). If neither is found, returns
+     * {@code false} so the caller can dispatch the 2-arg form.
      *
-     * @return true if the callback overload was invoked successfully
+     * @return true if either callback overload was invoked successfully
      */
     private boolean invokeWithCallback(MythicMobsHook hook, MythicMobRecord record, Location spawnLoc,
             Consumer<Entity> onSpawn) {
+        // Preferred: 4-arg overload with explicit zero delay.
+        try {
+            Method m = MythicMobsHook.class.getMethod("spawnMythicMob",
+                    MythicMobRecord.class, Location.class, Consumer.class, long.class);
+            m.invoke(hook, record, spawnLoc, onSpawn, 0L);
+            return true;
+        } catch (NoSuchMethodException ignored) {
+            // fall through to the 3-arg form
+        } catch (Exception e) {
+            BentoBox.getInstance().logError(
+                    "Failed to invoke MythicMobsHook 4-arg callback overload: " + e.getMessage());
+            return false;
+        }
+
+        // Fallback: 3-arg overload (40-tick built-in delay).
         try {
             Method m = MythicMobsHook.class.getMethod("spawnMythicMob",
                     MythicMobRecord.class, Location.class, Consumer.class);
@@ -155,7 +181,8 @@ public class MythicMobCustomBlock implements OneBlockCustomBlock {
         } catch (NoSuchMethodException e) {
             return false;
         } catch (Exception e) {
-            BentoBox.getInstance().logError("Failed to invoke MythicMobsHook callback overload: " + e.getMessage());
+            BentoBox.getInstance().logError(
+                    "Failed to invoke MythicMobsHook 3-arg callback overload: " + e.getMessage());
             return false;
         }
     }

--- a/src/main/resources/phases/0_plains.yml
+++ b/src/main/resources/phases/0_plains.yml
@@ -117,8 +117,10 @@
   #  # Spawner gotcha: without the Delay/MinSpawnDelay/... timing fields,
   #  # vanilla 1.21 places the spawner inactive (Delay:-1 = never tick).
   #  # Set them explicitly or the spawner appears but does nothing.
+  #  # Delay:0 makes the first spawn happen on the very next tick (instant);
+  #  # use Delay:N to wait N ticks before the first spawn instead.
   #  - type: block
-  #    data: 'spawner{Delay:20,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
+  #    data: 'spawner{Delay:0,MinSpawnDelay:200,MaxSpawnDelay:800,SpawnCount:1,SpawnRange:4,MaxNearbyEntities:6,RequiredPlayerRange:16,SpawnData:{entity:{id:breeze,CustomName:[{text:"Breezy Generator",color:"#f90606"}],CustomNameVisible:1b,Glowing:1b,active_effects:[{id:unluck,duration:200,ambient:1b,show_particles:1b}],attributes:[{id:scale,base:2f}]}}} replace'
   #    probability: 5
   #
   #  - type: mythic-mob


### PR DESCRIPTION
Two independent delays made block-placed spawners and mythic-mob bosses feel sluggish, appearing ~1-2 seconds after the magic block broke. Remove both:

1. MythicMobCustomBlock now prefers the 4-arg spawnMythicMob(record, loc, Consumer, long) overload from BentoBox 3.15.0+ with delayTicks=0, so the boss spawns on the current tick instead of after the hook's historical 40-tick (2s) delay. That delay exists for blueprint-paste callers and is dead time for AOneBlock's synchronous block replace. Reflection falls back to the 3-arg (40-tick) and 2-arg overloads on older BentoBox, so nothing breaks for users running BentoBox 3.13-3.14. MakeSpace still runs from the Consumer callback.

2. The example spawner NBT in the README and 0_plains.yml used Delay:20 (first spawn in 1s); switch to Delay:0 so the first spawn happens on the next tick (visually instant). Extend the "Spawner gotcha" callout with one sentence explaining Delay:0 vs Delay:N vs Delay:-1.

Companion BentoBox PR adds the 4-arg overload; until that release lands, the reflection fallback keeps behaviour identical to today.