### PR TITLE
refactor: use BentoBox CraftEngineHook instead of direct API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
             <id>bentoboxworld</id>
             <url>https://repo.codemc.org/repository/bentoboxworld/</url>
             <releases><enabled>true</enabled></releases>
-            <snapshots><enabled>false</enabled></snapshots>
+            <snapshots><enabled>true</enabled></snapshots>
         </repository>
         <!-- Paper API snapshots -->
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <mockito.version>5.11.0</mockito.version>
         <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
-        <bentobox.version>3.13.0</bentobox.version>
+        <bentobox.version>3.15.0-SNAPSHOT</bentobox.version>
         <items-adder.version>4.0.10</items-adder.version>
         <nexo.version>1.8.0</nexo.version>
         <craftengine.version>0.0.67</craftengine.version>
@@ -272,18 +272,6 @@
             <groupId>com.nexomc</groupId>
             <artifactId>nexo</artifactId>
             <version>${nexo.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>net.momirealms</groupId>
-            <artifactId>craft-engine-core</artifactId>
-            <version>${craftengine.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlock.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlock.java
@@ -7,12 +7,10 @@ import java.util.Optional;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 
-import net.momirealms.craftengine.bukkit.api.CraftEngineBlocks;
-import net.momirealms.craftengine.core.block.CustomBlock;
-import net.momirealms.craftengine.core.util.Key;
 import world.bentobox.aoneblock.AOneBlock;
 import world.bentobox.aoneblock.oneblocks.OneBlockCustomBlock;
 import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.hooks.CraftEngineHook;
 
 public class CraftEngineCustomBlock implements OneBlockCustomBlock {
     private final String blockId;
@@ -22,8 +20,7 @@ public class CraftEngineCustomBlock implements OneBlockCustomBlock {
     }
 
     public static Optional<CraftEngineCustomBlock> fromId(String id) {
-        CustomBlock block = CraftEngineBlocks.byId(Key.of(id));
-        if (block != null) {
+        if (CraftEngineHook.exists(id)) {
             return Optional.of(new CraftEngineCustomBlock(id));
         }
         return Optional.empty();
@@ -39,7 +36,10 @@ public class CraftEngineCustomBlock implements OneBlockCustomBlock {
     public void execute(AOneBlock addon, Block block) {
         try {
             block.setType(Material.AIR);
-            CraftEngineBlocks.place(block.getLocation(), Key.of(blockId), false);
+            if (!CraftEngineHook.placeBlock(block.getLocation(), blockId)) {
+                BentoBox.getInstance().logError("Could not place CraftEngine block " + blockId);
+                block.setType(Material.STONE);
+            }
         } catch (Exception e) {
             BentoBox.getInstance().logError("Could not place CraftEngine block " + blockId + ": " + e.getMessage());
             block.setType(Material.STONE);


### PR DESCRIPTION
## Summary

- `CraftEngineCustomBlock` now delegates to `CraftEngineHook` static methods from BentoBox instead of importing CraftEngine classes directly
- Removes the `craft-engine-core` compile dependency (no longer needed); `craft-engine-bukkit` is kept for `CraftEngineListener`
- Bumps `bentobox.version` to `3.15.0-SNAPSHOT` (requires BentoBoxWorld/BentoBox#2952)

## Context

BentoBoxWorld/BentoBox#2952 introduced `CraftEngineHook` as a centralised hook for CraftEngine, following the same pattern as `ItemsAdderHook` and `OraxenHook`. This PR removes the direct CraftEngine API calls from AOneBlock so the addon no longer needs to track CraftEngine's internal API independently of BentoBox.

**Depends on:** BentoBoxWorld/BentoBox#2952

## Test plan

- [ ] Phase YAML with CraftEngine block IDs (string form and `type: craftengine` map form) loads correctly
- [ ] Custom CraftEngine blocks spawn on the one-block when the phase is active
- [ ] Fallback to STONE occurs if the block ID is invalid
- [ ] `CraftEngineReloadEvent` still triggers AOneBlock phase reload via `CraftEngineListener`
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)