### PR TITLE
feat: drop populated bee nest in Plenty phase

### DIFF
--- a/src/main/resources/phases/8500_plenty.yml
+++ b/src/main/resources/phases/8500_plenty.yml
@@ -45,6 +45,10 @@
     DIRT_PATH: 1
     LIGHT_GRAY_TERRACOTTA: 1
     SUSPICIOUS_SAND: 1
+  custom-blocks:
+    - type: block
+      data: 'minecraft:bee_nest[honey_level=0,facing=north]{bees:[{entity_data:{id:"minecraft:bee"},min_ticks_in_hive:600,ticks_in_hive:0},{entity_data:{id:"minecraft:bee"},min_ticks_in_hive:600,ticks_in_hive:0},{entity_data:{id:"minecraft:bee"},min_ticks_in_hive:600,ticks_in_hive:0}]}'
+      probability: 1
   mobs:
     COW: 1
     DONKEY: 1


### PR DESCRIPTION
## Summary
- Adds a `bee_nest` custom block (3 bees inside, `honey_level=0`) to `8500_plenty.yml` at weight 1, matching the existing `HONEY_BLOCK`/`HONEYCOMB_BLOCK` density (~22 over the 1000-block phase)
- Closes the honey-farming gap in Plenty: the phase already drops honeycomb blocks, honey blocks, and honey bottles, but there was no way to obtain a hive to farm them
- Uses the `type: block` custom-block path, which falls back to `/setblock` for NBT-bearing data so the nest is pre-populated with bees

Refs #512

## Test plan
- [x] `OneBlocksManagerTest3` — phase YAML loads without errors (29 tests, 0 failures)
- [x] Live server: bee nests spawn from the magic block in Plenty with 3 bees inside; bees emerge during the day, pollinate flowers, and refill honey level
- [x] Live server: existing Plenty drops (honeycomb blocks, honey blocks, terracotta, etc.) still appear at roughly their old frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)