### PR TITLE
fix: resync magic block to client after entity-spawn cancel

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -527,12 +527,18 @@ public class BlockListener extends FlagListener implements Listener {
      * @param nextBlock - next block object containing entity info
      */
     private void handleEntitySpawn(Cancellable e, Island i, Player player, Block block, OneBlockObject nextBlock) {
-        if (!(e instanceof EntitySpawnEvent)) {
+        boolean cancelled = !(e instanceof EntitySpawnEvent);
+        if (cancelled) {
             e.setCancelled(true);
         }
         spawnEntity(nextBlock, block);
+        // Cancelling BlockBreakEvent at HIGHEST priority leaves the client with a
+        // mispredicted "block gone" state; resync the actual block to clear it.
+        if (cancelled && player != null) {
+            player.sendBlockChange(block.getLocation(), block.getBlockData());
+        }
         Bukkit.getPluginManager().callEvent(new MagicBlockEntityEvent(i,
-                player == null ? null : player.getUniqueId(), 
+                player == null ? null : player.getUniqueId(),
                         block, nextBlock.getEntityType()));
     }
 


### PR DESCRIPTION
## Summary
- When the magic block rolls a mob, `handleEntitySpawn` cancels the triggering `BlockBreakEvent` at `EventPriority.HIGHEST`. By that point the client has already played the "block disappearing" animation and predicted the block as gone, but the server never sends a corrective block-update packet.
- Result: the magic block appears transparent client-side until the chunk resyncs (typically on relog), even though the server still has the correct block.
- Fix: send the actual server-side block state back to the mining player immediately after the cancel, using `Player#sendBlockChange`.

## Test plan
- [x] Live server: mine the magic block until a mob roll. Block stays visible (no transparent void). Verified end-to-end.
- [x] Verified server-side state was already correct before the fix (relog confirmed); only the client display was wrong.
- [ ] No-op for non-cancelled paths (`EntitySpawnEvent`-triggered) and for null-player paths (minion breaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)