### PR TITLE
fix: skip chest particles that require typed data instead of crashing

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -892,7 +892,14 @@ public class BlockListener extends FlagListener implements Listener {
             return;
         }
         Color color = addon.getSettings().resolveChestColor(rarity);
-        Object particleData = Particle.DUST.equals(particle) ? new Particle.DustOptions(color, 1) : null;
+        Object particleData = null;
+        if (Particle.DUST.equals(particle)) {
+            particleData = new Particle.DustOptions(color, 1);
+        } else if (!Void.class.equals(particle.getDataType())) {
+            // Particle requires typed data we can't provide — skip rather than crash
+            addon.logWarning("Chest particle " + particle.name() + " requires extra data and cannot be used. Use DUST or a void-data particle.");
+            return;
+        }
         block.getWorld().spawnParticle(particle, block.getLocation().add(new Vector(0.5, 1.0, 0.5)), 50, 0.5,
                 0, 0.5, 1, particleData);
     }


### PR DESCRIPTION
## Summary
- `chestParticle()` previously only constructed particle data for `Particle.DUST`. For every other particle type, `particleData` stayed `null`, and `World#spawnParticle` would throw `IllegalArgumentException` if the configured particle required non-void data (e.g. `ITEM`, `BLOCK`, `ENTITY_EFFECT`).
- Detect particles whose `getDataType()` is non-`Void`, log a warning naming the configured particle, and return early instead of spawning.
- `DUST` and particles whose data type is `Void` continue to work unchanged.

## Test plan
- [ ] Configure a non-DUST particle that requires data (e.g. `ITEM`) and confirm a warning is logged instead of an exception.
- [ ] Configure `DUST` and confirm the existing rarity-colored dust still spawns.
- [ ] Configure a void-data particle (e.g. `FLAME`) and confirm it still spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)