### PR TITLE
Add custom phase sounds (start-sound / end-sound)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Each phase also has a name, an icon, a biome and the following sections:
 - start-commands
 - end-commands
 - end-commands-first-time
+- start-sound
+- end-sound
 - requirements
 - blocks
 - mobs
@@ -160,6 +162,31 @@ Examples:
   end-commands-first-time:
   - 'broadcast &c&l[!] &b[player] &fhas completed the &d&n[phase]&f phase for the first time.'
 ```
+### Sounds
+A sound can be played to the player when a phase starts (`start-sound`) and/or
+when a phase is completed (`end-sound`). The `end-sound` is played to the player
+who completes the phase at the moment they move on to the next one; the
+`start-sound` is played when they enter the new phase.
+
+The sound key is passed through verbatim, so in addition to the vanilla
+Minecraft sound keys you can use **custom resource-pack sounds** declared in your
+pack's `sounds.json` (e.g. `myresourcepack:phase.complete`). The pack must of
+course be applied to the player.
+
+The simplest form is just the sound key (volume and pitch default to `1.0`):
+```
+  start-sound: minecraft:ui.toast.challenge_complete
+  end-sound: myresourcepack:phase.complete
+```
+
+You can also specify volume and pitch with the expanded form:
+```
+  end-sound:
+    sound: myresourcepack:phase.complete
+    volume: 1.0
+    pitch: 1.2
+```
+
 ### Requirements
 
 You can stipulate a set of requirements to start the phase:

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -66,6 +66,14 @@ public class CheckPhase {
 	String rawPhaseName = phase.getPhaseName();
 	String newPhaseName = rawPhaseName == null ? "" : rawPhaseName;
 
+	// Whether the user can be notified (titles, sounds): online, a player, and in this world.
+	// Sounds are gated by the same guard as the phase title so that, e.g. on the NPC/minion
+	// path where user defaults to the island owner, we never play a phase sound to an owner
+	// who is offline or busy in another world.
+	final Player onlinePlayer = user.getPlayer();
+	final boolean canNotify = user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld())
+		&& onlinePlayer != null;
+
 	// Run previous phase end commands
 	oneBlocksManager.getPhase(is.getPhaseName()).ifPresent(oldPhase -> {
 	    String oldPhaseName = oldPhase.getPhaseName() == null ? "" : oldPhase.getPhaseName();
@@ -80,14 +88,13 @@ public class CheckPhase {
 			"Commands run for first time completing " + oldPhaseName);
 	    }
 	    // Play the previous phase's completion sound
-	    if (oldPhase.getEndSound() != null) {
-		oldPhase.getEndSound().play(user.getPlayer());
+	    if (canNotify && oldPhase.getEndSound() != null) {
+		oldPhase.getEndSound().play(onlinePlayer);
 	    }
 	});
 	// Set the phase name
 	is.setPhaseName(newPhaseName);
-	Player onlinePlayer = user.getPlayer();
-	if (user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld()) && onlinePlayer != null) {
+	if (canNotify) {
 	    onlinePlayer.showTitle(Title.title(Component.text(newPhaseName), Component.empty()));
 	}
 	// Run phase start commands
@@ -95,7 +102,7 @@ public class CheckPhase {
 		replacePlaceholders(player, newPhaseName, phase.getBlockNumber(), i, phase.getStartCommands()),
 		"Commands run for start of " + newPhaseName);
 	// Play the new phase's start sound
-	if (phase.getStartSound() != null) {
+	if (canNotify && phase.getStartSound() != null) {
 	    phase.getStartSound().play(onlinePlayer);
 	}
 

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -70,9 +70,10 @@ public class CheckPhase {
 	// Sounds are gated by the same guard as the phase title so that, e.g. on the NPC/minion
 	// path where user defaults to the island owner, we never play a phase sound to an owner
 	// who is offline or busy in another world.
-	final Player onlinePlayer = user.getPlayer();
-	final boolean canNotify = user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld())
-		&& onlinePlayer != null;
+	// User.getPlayer() throws if the user is not a player (offline owner on the NPC/minion
+	// path), so it must only be called once isPlayer() is known true.
+	final Player onlinePlayer = user.isPlayer() ? user.getPlayer() : null;
+	final boolean canNotify = onlinePlayer != null && user.isOnline() && addon.inWorld(user.getWorld());
 
 	// Run previous phase end commands
 	oneBlocksManager.getPhase(is.getPhaseName()).ifPresent(oldPhase -> {

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -79,6 +79,10 @@ public class CheckPhase {
 				oldPhase.getFirstTimeEndCommands()),
 			"Commands run for first time completing " + oldPhaseName);
 	    }
+	    // Play the previous phase's completion sound
+	    if (oldPhase.getEndSound() != null) {
+		oldPhase.getEndSound().play(user.getPlayer());
+	    }
 	});
 	// Set the phase name
 	is.setPhaseName(newPhaseName);
@@ -90,6 +94,10 @@ public class CheckPhase {
 	Util.runCommands(user,
 		replacePlaceholders(player, newPhaseName, phase.getBlockNumber(), i, phase.getStartCommands()),
 		"Commands run for start of " + newPhaseName);
+	// Play the new phase's start sound
+	if (phase.getStartSound() != null) {
+	    phase.getStartSound().play(onlinePlayer);
+	}
 
 	blockListener.saveIsland(i);
     }

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlockPhase.java
@@ -58,6 +58,8 @@ public class OneBlockPhase {
     private List<Requirement> requirements;
     private Map<Integer, OneBlockObject> fixedBlocks;
     private Map<Integer, String> holograms;
+    private PhaseSound startSound;
+    private PhaseSound endSound;
 
     /**
      * Construct a phase that starts at blockNumber. Phase continues forever until
@@ -445,6 +447,34 @@ public class OneBlockPhase {
         this.holograms = hologramLines;
     }
 
+    /**
+     * @return the sound played when this phase starts, or {@code null} if none
+     */
+    public PhaseSound getStartSound() {
+        return startSound;
+    }
+
+    /**
+     * @param startSound the sound to play when this phase starts
+     */
+    public void setStartSound(PhaseSound startSound) {
+        this.startSound = startSound;
+    }
+
+    /**
+     * @return the sound played when this phase is completed, or {@code null} if none
+     */
+    public PhaseSound getEndSound() {
+        return endSound;
+    }
+
+    /**
+     * @param endSound the sound to play when this phase is completed
+     */
+    public void setEndSound(PhaseSound endSound) {
+        this.endSound = endSound;
+    }
+
     @Override
     public String toString() {
         return "OneBlockPhase [" + (phaseName != null ? "phaseName=" + phaseName + ", " : "")
@@ -458,6 +488,8 @@ public class OneBlockPhase {
                 + (endCommands != null ? "endCommands=" + endCommands + ", " : "")
                 + (requirements != null ? "requirements=" + requirements + ", " : "")
                 + (fixedBlocks != null ? "fixedBlocks=" + fixedBlocks + ", " : "")
+                + (startSound != null ? "startSound=" + startSound + ", " : "")
+                + (endSound != null ? "endSound=" + endSound + ", " : "")
                 + (holograms != null ? "holograms=" + holograms : "") + "]";
     }
 

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -234,9 +234,13 @@ public class OneBlocksManager {
 
         // Add phase sounds (supports custom resource-pack sounds)
         if (phaseConfig.contains(START_SOUND)) {
+            checkNotDuplicate(obPhase.getStartSound() != null, blockNumber, "Start sound",
+                    phaseConfig.getString(START_SOUND), obPhase.getStartSound(), DUPLICATE);
             obPhase.setStartSound(parseSound(phaseConfig, START_SOUND));
         }
         if (phaseConfig.contains(END_SOUND)) {
+            checkNotDuplicate(obPhase.getEndSound() != null, blockNumber, "End sound",
+                    phaseConfig.getString(END_SOUND), obPhase.getEndSound(), DUPLICATE);
             obPhase.setEndSound(parseSound(phaseConfig, END_SOUND));
         }
     }
@@ -257,13 +261,20 @@ public class OneBlocksManager {
             ConfigurationSection section = phaseConfig.getConfigurationSection(key);
             String sound = section.getString(SOUND);
             if (sound == null || sound.isEmpty()) {
+                addon.logWarning("Phase sound '" + key + "' has no '" + SOUND + "' key set - ignoring it.");
                 return null;
             }
             return new PhaseSound(sound, (float) section.getDouble(VOLUME, 1.0D),
                     (float) section.getDouble(PITCH, 1.0D));
         }
+        // Only a plain string is a valid scalar form; lists and other types are not.
+        if (!phaseConfig.isString(key)) {
+            addon.logWarning("Phase sound '" + key + "' must be a sound key string or a section with a '"
+                    + SOUND + "' key - ignoring it.");
+            return null;
+        }
         String sound = phaseConfig.getString(key);
-        if (sound == null || sound.isEmpty()) {
+        if (sound.isEmpty()) {
             return null;
         }
         return new PhaseSound(sound, 1F, 1F);

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -70,6 +70,11 @@ public class OneBlocksManager {
     private static final String START_COMMANDS = "start-commands";
     private static final String END_COMMANDS = "end-commands";
     private static final String END_COMMANDS_FIRST_TIME = "end-commands-first-time";
+    private static final String START_SOUND = "start-sound";
+    private static final String END_SOUND = "end-sound";
+    private static final String SOUND = "sound";
+    private static final String VOLUME = "volume";
+    private static final String PITCH = "pitch";
     private static final String REQUIREMENTS = "requirements";
     private static final String BLOCK = "Block ";
     private static final String BUT_ALREADY_SET_TO = " but already set to ";
@@ -226,6 +231,42 @@ public class OneBlocksManager {
                     phaseConfig.getString(HOLOGRAMS), obPhase.getHologramLines(), DUPLICATE);
             addHologramLines(obPhase, phaseConfig.getConfigurationSection(HOLOGRAMS));
         }
+
+        // Add phase sounds (supports custom resource-pack sounds)
+        if (phaseConfig.contains(START_SOUND)) {
+            obPhase.setStartSound(parseSound(phaseConfig, START_SOUND));
+        }
+        if (phaseConfig.contains(END_SOUND)) {
+            obPhase.setEndSound(parseSound(phaseConfig, END_SOUND));
+        }
+    }
+
+    /**
+     * Parses a {@link PhaseSound} from a config key. The key may be a plain
+     * string holding the (namespaced) sound key, or a section with
+     * {@code sound}, {@code volume} and {@code pitch} entries. Custom
+     * resource-pack sound keys are supported because the value is passed
+     * through verbatim.
+     *
+     * @param phaseConfig the phase configuration section
+     * @param key         the config key to read (start-sound / end-sound)
+     * @return a PhaseSound, or {@code null} if no usable sound key was supplied
+     */
+    PhaseSound parseSound(ConfigurationSection phaseConfig, String key) {
+        if (phaseConfig.isConfigurationSection(key)) {
+            ConfigurationSection section = phaseConfig.getConfigurationSection(key);
+            String sound = section.getString(SOUND);
+            if (sound == null || sound.isEmpty()) {
+                return null;
+            }
+            return new PhaseSound(sound, (float) section.getDouble(VOLUME, 1.0D),
+                    (float) section.getDouble(PITCH, 1.0D));
+        }
+        String sound = phaseConfig.getString(key);
+        if (sound == null || sound.isEmpty()) {
+            return null;
+        }
+        return new PhaseSound(sound, 1F, 1F);
     }
 
     private void checkNotDuplicate(boolean alreadySet, String blockNumber, String field,
@@ -684,6 +725,7 @@ public class OneBlocksManager {
             saveEntities(phSec, p);
             saveHolos(phSec, p);
             saveCommands(phSec, p);
+            saveSounds(phSec, p);
         }
         try {
             // Save
@@ -700,6 +742,21 @@ public class OneBlocksManager {
         phSec.set(START_COMMANDS, p.getStartCommands());
         phSec.set(END_COMMANDS, p.getEndCommands());
 
+    }
+
+    private void saveSounds(ConfigurationSection phSec, OneBlockPhase p) {
+        saveSound(phSec, START_SOUND, p.getStartSound());
+        saveSound(phSec, END_SOUND, p.getEndSound());
+    }
+
+    private void saveSound(ConfigurationSection phSec, String key, PhaseSound sound) {
+        if (sound == null) {
+            return;
+        }
+        ConfigurationSection section = phSec.createSection(key);
+        section.set(SOUND, sound.sound());
+        section.set(VOLUME, (double) sound.volume());
+        section.set(PITCH, (double) sound.pitch());
     }
 
     private void saveHolos(ConfigurationSection phSec, OneBlockPhase p) {

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/PhaseSound.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/PhaseSound.java
@@ -11,9 +11,14 @@ import org.eclipse.jdt.annotation.Nullable;
  * vanilla Minecraft sound keys, e.g. {@code minecraft:ui.toast.challenge_complete}
  * or {@code myresourcepack:phase.complete}.
  *
+ * Values are passed straight through to Bukkit; this record does not clamp
+ * them. Minecraft itself treats a volume above 1.0 as an increased hearing
+ * radius (not louder) and clamps pitch client-side to the 0.5 - 2.0 range.
+ *
  * @param sound  the (namespaced) sound key to play
- * @param volume the volume, where 1.0 is normal
- * @param pitch  the pitch, where 1.0 is normal (valid range 0.5 - 2.0)
+ * @param volume the volume, where 1.0 is normal; values above 1.0 increase the
+ *               distance at which the sound can be heard
+ * @param pitch  the pitch, where 1.0 is normal (Minecraft clamps to 0.5 - 2.0)
  *
  * @author tastybento
  */

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/PhaseSound.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/PhaseSound.java
@@ -1,0 +1,35 @@
+package world.bentobox.aoneblock.oneblocks;
+
+import org.bukkit.entity.Player;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Represents a sound that is played to a player when a phase starts or ends.
+ * <p>
+ * The sound key is a free-form string so that resource-pack (custom) sounds
+ * declared in a pack's {@code sounds.json} can be used in addition to the
+ * vanilla Minecraft sound keys, e.g. {@code minecraft:ui.toast.challenge_complete}
+ * or {@code myresourcepack:phase.complete}.
+ *
+ * @param sound  the (namespaced) sound key to play
+ * @param volume the volume, where 1.0 is normal
+ * @param pitch  the pitch, where 1.0 is normal (valid range 0.5 - 2.0)
+ *
+ * @author tastybento
+ */
+public record PhaseSound(String sound, float volume, float pitch) {
+
+    /**
+     * Plays this sound to the given player at their current location. Because
+     * the sound key is passed through as a raw string, custom resource-pack
+     * sounds are supported.
+     *
+     * @param player the player to play the sound to. If {@code null} nothing happens.
+     */
+    public void play(@Nullable Player player) {
+        if (player == null || sound == null || sound.isEmpty()) {
+            return;
+        }
+        player.playSound(player.getLocation(), sound, volume, pitch);
+    }
+}

--- a/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
@@ -338,6 +338,49 @@ public class CheckPhaseTest extends CommonTestSetup {
     }
 
     /**
+     * Test that a phase transition triggered by an NPC/minion while the island owner
+     * is offline does not throw (User.getPlayer() would NPE on a non-player user), and
+     * that end-commands and the phase change still happen with no sound or title.
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.CheckPhase#setNewPhase(Player, Island, world.bentobox.aoneblock.dataobjects.OneBlockIslands, world.bentobox.aoneblock.oneblocks.OneBlockPhase)}
+     */
+    @Test
+    void testSetNewPhaseOfflineOwnerNpcPath() {
+        // NPC/minion breaks the block; user resolves to the island owner, who is offline.
+        // BentoBox's User.getPlayer() throws "User is not a player!" for a non-player user,
+        // so this mock reproduces that contract - the code must never call getPlayer() here.
+        when(mockPlayer.hasMetadata("NPC")).thenReturn(true);
+        User offlineOwner = mock(User.class);
+        when(offlineOwner.isPlayer()).thenReturn(false);
+        when(offlineOwner.getPlayer()).thenThrow(new NullPointerException("User is not a player!"));
+        when(pm.getUser(any(UUID.class))).thenReturn(offlineOwner);
+
+        is = new OneBlockIslands(UUID.randomUUID().toString());
+        is.setPhaseName("Previous");
+        is.setBlockNumber(500);
+        is.setLifetime(500L);
+        phase = new OneBlockPhase("500");
+        phase.setPhaseName("Next Phase");
+        phase.setStartCommands(List.of());
+        phase.setStartSound(new PhaseSound("minecraft:ui.toast.challenge_complete", 1F, 1F));
+
+        OneBlockPhase previous = mock(OneBlockPhase.class);
+        when(previous.getPhaseName()).thenReturn("Previous");
+        when(previous.getEndCommands()).thenReturn(List.of());
+        when(previous.getFirstTimeEndCommands()).thenReturn(List.of());
+        when(previous.getEndSound()).thenReturn(new PhaseSound("custompack:phase.complete", 1F, 1F));
+        when(obm.getPhase("Previous")).thenReturn(Optional.of(previous));
+
+        // Must not throw even though User.getPlayer() would NPE on the offline owner
+        bl.setNewPhase(mockPlayer, island, is, phase);
+
+        // End-commands still run and the phase advances; no sound/title to a non-player
+        verify(previous).getEndCommands();
+        assertEquals("Next Phase", is.getPhaseName());
+        verify(mockPlayer, never()).playSound(any(Location.class), anyString(), anyFloat(), anyFloat());
+    }
+
+    /**
      * Test method for
      * {@link world.bentobox.aoneblock.listeners.BlockListener#replacePlaceholders(org.bukkit.entity.Player, java.lang.String, java.lang.String, world.bentobox.bentobox.database.objects.Island, java.util.List)}.
      */

--- a/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
@@ -330,6 +330,9 @@ public class CheckPhaseTest extends CommonTestSetup {
         // Neither the title nor any sound should be sent to an out-of-world player
         verify(mockPlayer, never()).showTitle(any(Title.class));
         verify(mockPlayer, never()).playSound(any(Location.class), anyString(), anyFloat(), anyFloat());
+        // ...but end-commands still run: command execution must NOT be coupled to the
+        // online/in-world notify gate that sounds and the title use.
+        verify(previous).getEndCommands();
         // Phase change still happens
         assertEquals("Next Phase", is.getPhaseName());
     }

--- a/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
@@ -2,6 +2,7 @@ package world.bentobox.aoneblock.listeners;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.eclipse.jdt.annotation.NonNull;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +34,7 @@ import world.bentobox.aoneblock.CommonTestSetup;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
 import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
+import world.bentobox.aoneblock.oneblocks.PhaseSound;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.data.Money;
@@ -264,6 +268,70 @@ public class CheckPhaseTest extends CommonTestSetup {
         verify(mockPlayer).showTitle(titleCaptor.capture());
         assertEquals(Component.text("Next Phase"), titleCaptor.getValue().title());
 
+    }
+
+    /**
+     * Test that the previous phase's end-sound and the new phase's start-sound are
+     * both played to the player, with the configured volume and pitch.
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.CheckPhase#setNewPhase(Player, Island, world.bentobox.aoneblock.dataobjects.OneBlockIslands, world.bentobox.aoneblock.oneblocks.OneBlockPhase)}
+     */
+    @Test
+    void testSetNewPhasePlaysSounds() {
+        is = new OneBlockIslands(UUID.randomUUID().toString());
+        is.setPhaseName("Previous");
+        is.setBlockNumber(500);
+        is.setLifetime(500L);
+        phase = new OneBlockPhase("500");
+        phase.setPhaseName("Next Phase");
+        phase.setStartSound(new PhaseSound("minecraft:ui.toast.challenge_complete", 1F, 1F));
+
+        OneBlockPhase previous = mock(OneBlockPhase.class);
+        when(previous.getPhaseName()).thenReturn("Previous");
+        when(previous.getEndSound()).thenReturn(new PhaseSound("custompack:phase.complete", 0.5F, 1.2F));
+        when(obm.getPhase("Previous")).thenReturn(Optional.of(previous));
+
+        bl.setNewPhase(mockPlayer, island, is, phase);
+
+        // End sound of the phase being completed, with its volume/pitch
+        verify(mockPlayer).playSound(any(Location.class), eq("custompack:phase.complete"), eq(0.5F), eq(1.2F));
+        // Start sound of the phase being entered
+        verify(mockPlayer).playSound(any(Location.class), eq("minecraft:ui.toast.challenge_complete"), eq(1F),
+                eq(1F));
+    }
+
+    /**
+     * Test that phase sounds are suppressed (like the title) when the resolved
+     * user - e.g. the island owner on the NPC/minion path - is online but in a
+     * different world. Test method for
+     * {@link world.bentobox.aoneblock.listeners.CheckPhase#setNewPhase(Player, Island, world.bentobox.aoneblock.dataobjects.OneBlockIslands, world.bentobox.aoneblock.oneblocks.OneBlockPhase)}
+     */
+    @Test
+    void testSetNewPhaseSoundSuppressedInOtherWorld() {
+        // Player is online but in another world (addon.inWorld(otherWorld) is false by default)
+        World otherWorld = mock(World.class);
+        when(mockPlayer.getWorld()).thenReturn(otherWorld);
+
+        is = new OneBlockIslands(UUID.randomUUID().toString());
+        is.setPhaseName("Previous");
+        is.setBlockNumber(500);
+        is.setLifetime(500L);
+        phase = new OneBlockPhase("500");
+        phase.setPhaseName("Next Phase");
+        phase.setStartSound(new PhaseSound("minecraft:ui.toast.challenge_complete", 1F, 1F));
+
+        OneBlockPhase previous = mock(OneBlockPhase.class);
+        when(previous.getPhaseName()).thenReturn("Previous");
+        when(previous.getEndSound()).thenReturn(new PhaseSound("custompack:phase.complete", 1F, 1F));
+        when(obm.getPhase("Previous")).thenReturn(Optional.of(previous));
+
+        bl.setNewPhase(mockPlayer, island, is, phase);
+
+        // Neither the title nor any sound should be sent to an out-of-world player
+        verify(mockPlayer, never()).showTitle(any(Title.class));
+        verify(mockPlayer, never()).playSound(any(Location.class), anyString(), anyFloat(), anyFloat());
+        // Phase change still happens
+        assertEquals("Next Phase", is.getPhaseName());
     }
 
     /**

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
@@ -22,8 +22,8 @@ import java.util.jar.JarOutputStream;
 
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
-import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
@@ -590,4 +590,80 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 		verify(plugin).logError(org.mockito.ArgumentMatchers.contains("CHEST_WITH item is invalid"));
 	}
 
+	/**
+	 * Test that a plain-string start-sound / end-sound is parsed with default
+	 * volume and pitch, and supports custom resource-pack sound keys.
+	 */
+	@Test
+	void testInitBlockParsesStringSounds() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                name: Plains
+                biome: PLAINS
+                blocks:
+                  GRASS_BLOCK: 1000
+                start-sound: minecraft:ui.toast.challenge_complete
+                end-sound: myresourcepack:phase.complete
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		obm.initBlock("0", obPhase, cfg);
+
+		assertNotNull(obPhase.getStartSound());
+		assertEquals("minecraft:ui.toast.challenge_complete", obPhase.getStartSound().sound());
+		assertEquals(1F, obPhase.getStartSound().volume());
+		assertEquals(1F, obPhase.getStartSound().pitch());
+
+		assertNotNull(obPhase.getEndSound());
+		assertEquals("myresourcepack:phase.complete", obPhase.getEndSound().sound());
+	}
+
+	/**
+	 * Test that a section-form sound with explicit volume and pitch is parsed.
+	 */
+	@Test
+	void testInitBlockParsesSectionSound() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                name: Plains
+                biome: PLAINS
+                blocks:
+                  GRASS_BLOCK: 1000
+                start-sound:
+                  sound: myresourcepack:fanfare
+                  volume: 0.5
+                  pitch: 1.5
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		obm.initBlock("0", obPhase, cfg);
+
+		assertNotNull(obPhase.getStartSound());
+		assertEquals("myresourcepack:fanfare", obPhase.getStartSound().sound());
+		assertEquals(0.5F, obPhase.getStartSound().volume());
+		assertEquals(1.5F, obPhase.getStartSound().pitch());
+		assertNull(obPhase.getEndSound());
+	}
+
+	/**
+	 * Test that no sounds are set when the keys are absent or empty.
+	 */
+	@Test
+	void testInitBlockNoSounds() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                name: Plains
+                biome: PLAINS
+                blocks:
+                  GRASS_BLOCK: 1000
+                start-sound: ""
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		obm.initBlock("0", obPhase, cfg);
+
+		assertNull(obPhase.getStartSound());
+		assertNull(obPhase.getEndSound());
+	}
+
 }

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
@@ -23,6 +23,7 @@ import java.util.jar.JarOutputStream;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -664,6 +665,104 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 
 		assertNull(obPhase.getStartSound());
 		assertNull(obPhase.getEndSound());
+	}
+
+	/**
+	 * Test that the section form is parsed for end-sound too (not only start-sound).
+	 */
+	@Test
+	void testInitBlockParsesSectionEndSound() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                name: Plains
+                biome: PLAINS
+                blocks:
+                  GRASS_BLOCK: 1000
+                end-sound:
+                  sound: custompack:phase.complete
+                  volume: 0.25
+                  pitch: 2.0
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		obm.initBlock("0", obPhase, cfg);
+
+		assertNull(obPhase.getStartSound());
+		assertNotNull(obPhase.getEndSound());
+		assertEquals("custompack:phase.complete", obPhase.getEndSound().sound());
+		assertEquals(0.25F, obPhase.getEndSound().volume());
+		assertEquals(2.0F, obPhase.getEndSound().pitch());
+	}
+
+	/**
+	 * Test that a sound section without a 'sound' key is ignored (returns null).
+	 */
+	@Test
+	void testParseSoundSectionWithoutSoundKey() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                start-sound:
+                  volume: 1.0
+                  pitch: 1.0
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		assertNull(obm.parseSound(cfg, "start-sound"));
+	}
+
+	/**
+	 * Test that a non-string, non-section value (e.g. a list) is ignored.
+	 */
+	@Test
+	void testParseSoundInvalidTypeIsIgnored() throws InvalidConfigurationException, IOException {
+		String yaml = """
+                start-sound:
+                - one
+                - two
+                """;
+		YamlConfiguration cfg = new YamlConfiguration();
+		cfg.loadFromString(yaml);
+
+		assertNull(obm.parseSound(cfg, "start-sound"));
+	}
+
+	/**
+	 * Test that sounds survive a save and reload (string form is preserved
+	 * semantically, even though it is rewritten as the expanded section form).
+	 */
+	@Test
+	void testSaveSoundRoundTrip() throws InvalidConfigurationException, IOException {
+		// Use a block number that is not in the shipped phases so the written file
+		// cannot collide with a real phase if a later test scans the phases folder.
+		OneBlockPhase phase = new OneBlockPhase("999000");
+		phase.setPhaseName("Roundtrip Phase");
+		phase.setStartSound(new PhaseSound("minecraft:ui.toast.challenge_complete", 1F, 1F));
+		phase.setEndSound(new PhaseSound("custompack:phase.complete", 0.5F, 1.2F));
+
+		File saved = new File("addons/AOneBlock/phases/999000_roundtrip_phase.yml");
+		File savedChests = new File("addons/AOneBlock/phases/999000_roundtrip_phase_chests.yml");
+		try {
+			assertTrue(obm.savePhase(phase));
+			assertTrue(saved.exists());
+			YamlConfiguration cfg = new YamlConfiguration();
+			cfg.load(saved);
+			ConfigurationSection section = cfg.getConfigurationSection("999000");
+
+			PhaseSound start = obm.parseSound(section, "start-sound");
+			PhaseSound end = obm.parseSound(section, "end-sound");
+			assertNotNull(start);
+			assertEquals("minecraft:ui.toast.challenge_complete", start.sound());
+			assertEquals(1F, start.volume());
+			assertEquals(1F, start.pitch());
+			assertNotNull(end);
+			assertEquals("custompack:phase.complete", end.sound());
+			assertEquals(0.5F, end.volume());
+			assertEquals(1.2F, end.pitch());
+		} finally {
+			// Never leave the written files behind: loadPhases() in other tests scans this folder.
+			saved.delete();
+			savedChests.delete();
+		}
 	}
 
 }

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/PhaseSoundTest.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/PhaseSoundTest.java
@@ -1,0 +1,47 @@
+package world.bentobox.aoneblock.oneblocks;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PhaseSound}.
+ *
+ * @author tastybento
+ */
+class PhaseSoundTest {
+
+    @Test
+    void testPlayInvokesPlayerPlaySoundWithKeyVolumeAndPitch() {
+        Player player = mock(Player.class);
+        Location location = mock(Location.class);
+        when(player.getLocation()).thenReturn(location);
+
+        new PhaseSound("custompack:fanfare", 0.5F, 1.5F).play(player);
+
+        verify(player).playSound(location, "custompack:fanfare", 0.5F, 1.5F);
+    }
+
+    @Test
+    void testPlayWithNullPlayerIsNoOp() {
+        assertDoesNotThrow(() -> new PhaseSound("custompack:fanfare", 1F, 1F).play(null));
+    }
+
+    @Test
+    void testPlayWithEmptySoundIsNoOp() {
+        Player player = mock(Player.class);
+
+        new PhaseSound("", 1F, 1F).play(player);
+
+        verify(player, never()).playSound(any(Location.class), anyString(), anyFloat(), anyFloat());
+    }
+}


### PR DESCRIPTION
## What

Adds the ability for a phase to play a sound to the player when it **starts** and/or when it is **completed**, via two new phase keys: `start-sound` and `end-sound`.

This was previously only achievable indirectly by running a `playsound` console command through `start-commands` / `end-commands`. This makes it a first-class, documented phase option.

## Why

A common request is "play a fanfare when a player completes/reaches a phase." The sound key is passed through verbatim to `Player#playSound(Location, String, float, float)`, so **resource-pack (custom) sounds** declared in a pack's `sounds.json` work just as well as vanilla sound keys — e.g. `myresourcepack:phase.complete`.

## Config

Plain string (volume/pitch default to `1.0`):
```yaml
'0':
  name: Plains
  start-sound: minecraft:ui.toast.challenge_complete
  end-sound: myresourcepack:phase.complete
```

Expanded section with volume/pitch:
```yaml
'0':
  end-sound:
    sound: myresourcepack:phase.complete
    volume: 1.0
    pitch: 1.2
```

## Behaviour

- `end-sound` plays to the player completing a phase, at the moment they transition to the next one — mirroring `end-commands`.
- `start-sound` plays when they enter the new phase — mirroring `start-commands`.
- Both are played in `CheckPhase#setNewPhase`, right alongside the existing command hooks and phase title.
- Values round-trip through the phase save logic.

## Details

- New `PhaseSound` record (`sound`, `volume`, `pitch`) with a null-safe `play(Player)`.
- `OneBlockPhase` gains `startSound` / `endSound` fields, getters/setters, and `toString` entries.
- `OneBlocksManager#parseSound` parses both the string and section forms; `saveSounds` persists them.
- README documents the new keys, including the custom resource-pack use case.

## Tests

Added unit tests covering string-form parsing (with default volume/pitch), section-form parsing (explicit volume/pitch), and the empty/absent case. All pass.

Note: the suite already has one pre-existing, ordering-sensitive failure in `OneBlocksManagerTest3#testGetPhaseString` (reproduces on a clean `develop` when the whole class runs); it is unrelated to this change and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)