### PR TITLE
Fix NPE when a minion breaks the magic block (#525)

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -350,8 +350,11 @@ public class BlockListener extends FlagListener implements Listener {
      * @param world - world where the block is being broken
      */
     private void process(@NonNull Cancellable e, @NonNull Island island, @Nullable Player player, @NonNull World world) {
-        // Check if the player has authority to break the magic block
-        if (!checkIsland((@NonNull Event) e, player, island.getCenter(), addon.MAGIC_BLOCK)) {
+        // Check if the player has authority to break the magic block. When there is no
+        // player (e.g. the block is broken by a JetsMinions minion) the protection flag
+        // check is skipped: it requires a User and would otherwise throw an NPE inside
+        // BentoBox's FlagListener. See https://github.com/BentoBoxWorld/AOneBlock/issues/525
+        if (player != null && !checkIsland((@NonNull Event) e, player, island.getCenter(), addon.MAGIC_BLOCK)) {
             // Not allowed
             return;
         }

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
@@ -9,8 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -70,6 +72,7 @@ import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.data.Money;
+import world.bentobox.bentobox.api.events.island.IslandCreatedEvent;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.AbstractDatabaseHandler;
 import world.bentobox.bentobox.database.DatabaseSetup;
@@ -115,7 +118,6 @@ class BlockListenerTest2 extends CommonTestSetup {
     private MockedStatic<DatabaseSetup> mockDb;
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -1002,6 +1004,31 @@ class BlockListenerTest2 extends CommonTestSetup {
 
         // Not an armor stand → early return, no processing
         verify(im, never()).getIslandAt(any());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakByMinion(EntityInteractEvent)}
+     * Regression test for https://github.com/BentoBoxWorld/AOneBlock/issues/525 —
+     * a minion (armor stand) breaking the magic block has no associated player, so the
+     * protection-flag check must be skipped rather than passing a null player into
+     * BentoBox's FlagListener (which would throw an NPE). The break should be processed
+     * so the magic block respawns.
+     */
+    @Test
+    void testOnBlockBreakByMinionProcessesWithoutPlayer() {
+        when(obm.getPhase(anyInt())).thenReturn(phase);
+
+        EntityInteractEvent e = mock(EntityInteractEvent.class);
+        when(e.getBlock()).thenReturn(magicBlock);
+        when(e.getEntityType()).thenReturn(EntityType.ARMOR_STAND);
+        when(magicBlock.getWorld()).thenReturn(world);
+
+        // Must not throw an NPE from the flag check
+        assertDoesNotThrow(() -> bl.onBlockBreakByMinion(e));
+
+        // Processing proceeded past the (skipped) flag check into phase handling
+        verify(obm, atLeastOnce()).getPhase(anyInt());
     }
 
     /**


### PR DESCRIPTION
Fixes #525

## Problem

When the JetsMinions Miner minion (an armor stand) breaks the magic block, the block disappears and never respawns, and the console logs an NPE. It must be restored manually with `/ob respawnBlock`.

```
java.lang.NullPointerException: Cannot invoke "world.bentobox.bentobox.api.user.User.getMetaData(String)" because "this.user" is null
	at ...FlagListener.hasBypassEverywhere(FlagListener.java:216)
	at ...FlagListener.checkIsland(FlagListener.java:179)
	at ...BlockListener.process(BlockListener.java:354)
	at ...BlockListener.lambda$onBlockBreakByMinion$1(BlockListener.java:249)
```

## Root cause

`onBlockBreakByMinion` calls `process(...)` with `player == null` (a minion has no player). `process` then called BentoBox's `checkIsland(event, null, ...)`, which sets `user = null` and later dereferences it in `hasBypassEverywhere` → NPE. The handler aborts before the block can respawn.

This is why the issue only appears from **1.22.0** onward — that release introduced the `MAGIC_BLOCK` protection flag and thus this `checkIsland` call. Earlier versions never ran the flag check on the minion path.

## Fix

Skip the protection-flag check when there is no player:

```java
if (player != null && !checkIsland((@NonNull Event) e, player, island.getCenter(), addon.MAGIC_BLOCK)) {
    return;
}
```

The flag check evaluates a *user's* permissions; there is no user for a minion, so it cannot apply. This restores the pre-1.22.0 minion behaviour while keeping full protection for real players. It's also consistent with the existing "minions cannot fulfill requirements" branch in `CheckPhase.phaseRequirementsFail`.

## Testing

Added `testOnBlockBreakByMinionProcessesWithoutPlayer` in `BlockListenerTest2`, which asserts a minion break no longer throws and processing continues past the flag check into phase handling (so the block respawns). All `BlockListener` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)