### PR TITLE
Resolve SonarCloud issues and Javadoc cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>5.11.0</version>

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -35,7 +35,6 @@ public class CheckPhase {
 
     /**
      * @param addon         AOneBlock
-     * @param blockListener
      */
     public CheckPhase(AOneBlock addon, BlockListener blockListener) {
 	this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -81,9 +81,10 @@ public class CheckPhase {
 	});
 	// Set the phase name
 	is.setPhaseName(newPhaseName);
-	Player onlinePlayer = user.getPlayer();
-	if (user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld()) && onlinePlayer != null) {
-	    onlinePlayer.showTitle(Title.title(Component.text(newPhaseName), Component.empty()));
+	// user.getPlayer() is @NonNull and throws for non-players, so it must be
+	// called only after isPlayer() has short-circuited.
+	if (user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld())) {
+	    user.getPlayer().showTitle(Title.title(Component.text(newPhaseName), Component.empty()));
 	}
 	// Run phase start commands
 	Util.runCommands(user,

--- a/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
@@ -40,7 +40,6 @@ public class MakeSpace {
 
 
     /**
-     * @param addon
      */
     public MakeSpace(AOneBlock addon) {
         this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/listeners/WarningSounder.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/WarningSounder.java
@@ -27,7 +27,6 @@ public class WarningSounder {
     private final AOneBlock addon;
 
     /**
-     * @param addon
      */
     public WarningSounder(AOneBlock addon) {
         this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -52,6 +52,7 @@ import world.bentobox.bentobox.util.Util;
 public class OneBlocksManager {
 
     private static final String ONE_BLOCKS_YML = "oneblocks.yml";
+    private static final String FIXED_BLOCK_KEY = "Fixed block key ";
     private static final String NAME = "name";
     private static final String BIOME = "biome";
     private static final String FIRST_BLOCK = "firstBlock";
@@ -292,7 +293,7 @@ public class OneBlocksManager {
         if (customBlock.isPresent()) {
             result.put(k, new OneBlockObject(customBlock.get(), 0));
         } else {
-            addon.logError("Fixed block key " + key + " material is not a valid custom block. Ignoring.");
+            addon.logError(FIXED_BLOCK_KEY + key + " material is not a valid custom block. Ignoring.");
         }
     }
 
@@ -328,7 +329,7 @@ public class OneBlocksManager {
             if (m != null && m.isBlock()) {
                 result.put(k, new OneBlockObject(m, 0));
             } else {
-                addon.logError("Fixed block key " + key + " material is invalid or not a block. Ignoring.");
+                addon.logError(FIXED_BLOCK_KEY + key + " material is invalid or not a block. Ignoring.");
             }
         }
     }
@@ -346,7 +347,7 @@ public class OneBlocksManager {
     private void parseChestWithItem(Map<Integer, OneBlockObject> result, String key, int k, String itemName) {
         Material item = Material.matchMaterial(itemName);
         if (item == null) {
-            addon.logError("Fixed block key " + key + " CHEST_WITH item is invalid: " + itemName + ". Ignoring.");
+            addon.logError(FIXED_BLOCK_KEY + key + " CHEST_WITH item is invalid: " + itemName + ". Ignoring.");
             return;
         }
         Map<Integer, ItemStack> chestContents = new HashMap<>();

--- a/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
+++ b/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
@@ -590,7 +590,7 @@ public class PhasesPanel
         int lastAmpIndex = -2;
 
         while (index < input.length()) {
-            if (input.charAt(index) == '\u00A7' && index < (input.length() - 1)) {
+            if (input.charAt(index) == '§' && index < (input.length() - 1)) {
                 lastAmpIndex = index;
                 activeColor = input.charAt(index + 1);
             }
@@ -608,7 +608,7 @@ public class PhasesPanel
             result.append(input, index, breakPoint).append('\n');
             if (lastAmpIndex >= 0) {
                 // Append color code
-                result.append('\u00A7');
+                result.append('§');
                 result.append(activeColor);
                 result.append(" ");
             }

--- a/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
+++ b/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -72,7 +71,6 @@ public class AOneBlockTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override

--- a/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
@@ -27,16 +27,13 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Player.Spigot;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemFactory;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -283,7 +280,9 @@ public abstract class CommonTestSetup {
         List<TextComponent> capturedMessages = captor.getAllValues();
 
         // Count the number of occurrences of the expectedMessage in the captured messages
-        long actualOccurrences = capturedMessages.stream().map(component -> component.toLegacyText()) // Convert each TextComponent to plain text
+        // NOSONAR S1612: BaseComponent overloads toLegacyText() (instance) and toLegacyText(BaseComponent...) (static),
+        // so a method reference is ambiguous and will not compile; the lambda is required.
+        long actualOccurrences = capturedMessages.stream().map(component -> component.toLegacyText()) // NOSONAR
                 .filter(messageText -> messageText.contains(expectedMessage)) // Check if the message contains the expected text
                 .count(); // Count how many times the expected message appears
 
@@ -297,13 +296,6 @@ public abstract class CommonTestSetup {
      */
     public EntityExplodeEvent getExplodeEvent(Entity entity, Location l, List<Block> list) {
         return new EntityExplodeEvent(entity, l, list, 0, org.bukkit.ExplosionResult.DESTROY);
-    }
-
-    public PlayerDeathEvent getPlayerDeathEvent(Player player, List<ItemStack> drops, int droppedExp, int newExp,
-            int newTotalExp, int newLevel, @Nullable String deathMessage) {
-        //Technically this null is not allowed, but it works right now
-        return new PlayerDeathEvent(player, null, drops, droppedExp, newExp,
-                newTotalExp, newLevel, deathMessage);
     }
 
 }

--- a/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
@@ -242,7 +242,6 @@ public abstract class CommonTestSetup {
     }
 
     /**
-     * @throws Exception
      */
     @AfterEach
     public void tearDown() throws Exception {
@@ -266,7 +265,7 @@ public abstract class CommonTestSetup {
 
     /**
      * Check that spigot sent the message
-     * @param message - message to check
+     * @param expectedMessage - message to check
      */
     public void checkSpigotMessage(String expectedMessage) {
         checkSpigotMessage(expectedMessage, 1);
@@ -295,10 +294,6 @@ public abstract class CommonTestSetup {
 
     /**
      * Get the exploded event
-     * @param entity
-     * @param l
-     * @param list
-     * @return
      */
     public EntityExplodeEvent getExplodeEvent(Entity entity, Location l, List<Block> list) {
         return new EntityExplodeEvent(entity, l, list, 0, org.bukkit.ExplosionResult.DESTROY);

--- a/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
@@ -35,7 +35,6 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
     private OneBlocksManager obm;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/SettingsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/SettingsTest.java
@@ -247,7 +247,8 @@ public class SettingsTest extends CommonTestSetup {
     /**
      * Test method for {@link world.bentobox.aoneblock.Settings#getDefaultIslandFlags()}.
      */
-    @SuppressWarnings("deprecation")
+    // Intentionally exercises a deprecated-for-removal override; keep until BentoBox drops it.
+    @SuppressWarnings({ "deprecation", "removal", "java:S5738" })
     @Test
     void testGetDefaultIslandFlags() {
         assertTrue(s.getDefaultIslandFlags().isEmpty());
@@ -256,7 +257,8 @@ public class SettingsTest extends CommonTestSetup {
     /**
      * Test method for {@link world.bentobox.aoneblock.Settings#getDefaultIslandSettings()}.
      */
-    @SuppressWarnings("deprecation")
+    // Intentionally exercises a deprecated-for-removal override; keep until BentoBox drops it.
+    @SuppressWarnings({ "deprecation", "removal", "java:S5738" })
     @Test
     void testGetDefaultIslandSettings() {
         assertTrue(s.getDefaultIslandSettings().isEmpty());

--- a/src/test/java/world/bentobox/aoneblock/SettingsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/SettingsTest.java
@@ -27,7 +27,6 @@ public class SettingsTest extends CommonTestSetup {
     private Settings s;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -37,7 +36,6 @@ public class SettingsTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandActionBarCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandActionBarCommandTest.java
@@ -38,7 +38,6 @@ class IslandActionBarCommandTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -54,7 +53,6 @@ class IslandActionBarCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandBossBarCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandBossBarCommandTest.java
@@ -41,7 +41,6 @@ class IslandBossBarCommandTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -65,7 +64,6 @@ class IslandBossBarCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommandTest.java
@@ -40,7 +40,6 @@ class IslandPhasesCommandTest extends CommonTestSetup {
     private IslandPhasesCommand ipc;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -61,7 +60,6 @@ class IslandPhasesCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommandTest.java
@@ -48,7 +48,6 @@ class IslandRespawnBlockCommandTest extends CommonTestSetup {
     private @NotNull Block block;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -74,7 +73,6 @@ class IslandRespawnBlockCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommandTest.java
@@ -72,7 +72,6 @@ public class IslandSetCountCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override

--- a/src/test/java/world/bentobox/aoneblock/dataobjects/OneBlockIslandsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/dataobjects/OneBlockIslandsTest.java
@@ -28,7 +28,6 @@ public class OneBlockIslandsTest extends CommonTestSetup {
     private String id;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -39,7 +38,6 @@ public class OneBlockIslandsTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest.java
@@ -71,7 +71,6 @@ public class BlockListenerTest extends CommonTestSetup {
     private @NonNull OneBlockPhase phase;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockProtectTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockProtectTest.java
@@ -56,7 +56,6 @@ public class BlockProtectTest extends CommonTestSetup {
     private Block block;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -88,7 +87,6 @@ public class BlockProtectTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
@@ -68,7 +68,6 @@ public class CheckPhaseTest extends CommonTestSetup {
     private Level level;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -118,7 +117,6 @@ public class CheckPhaseTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach
@@ -266,10 +264,6 @@ public class CheckPhaseTest extends CommonTestSetup {
 
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.aoneblock.listeners.BlockListener#replacePlaceholders(org.bukkit.entity.Player, java.lang.String, java.lang.String, world.bentobox.bentobox.database.objects.Island, java.util.List)}.
-     */
     @Test
     void testReplacePlaceholders() {
         // Commands

--- a/src/test/java/world/bentobox/aoneblock/listeners/HoloListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/HoloListenerTest.java
@@ -58,7 +58,6 @@ public class HoloListenerTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/InfoListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/InfoListenerTest.java
@@ -42,7 +42,6 @@ public class InfoListenerTest extends CommonTestSetup {
     private static final UUID ID = UUID.randomUUID();
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/JoinLeaveListenerTest.java
@@ -34,7 +34,6 @@ public class JoinLeaveListenerTest extends CommonTestSetup {
     private static final UUID ID = UUID.randomUUID();
     private static final Vector VECTOR = new Vector(123,120,456);
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -62,7 +61,6 @@ public class JoinLeaveListenerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/NoBlockHandlerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/NoBlockHandlerTest.java
@@ -39,7 +39,6 @@ public class NoBlockHandlerTest extends CommonTestSetup {
     private BlockListener bl;
  
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -71,7 +70,6 @@ public class NoBlockHandlerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/StartSafetyListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/StartSafetyListenerTest.java
@@ -46,7 +46,6 @@ public class StartSafetyListenerTest extends CommonTestSetup {
 
     private final @NonNull WSettings ws = new WSettings();
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -82,7 +81,6 @@ public class StartSafetyListenerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
@@ -116,8 +116,7 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	}
 
 	/**
-	 * @throws java.lang.Exception
-	 */
+     */
 	@SuppressWarnings("unchecked")
 	@Override
 	@BeforeEach
@@ -154,8 +153,7 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	}
 
 	/**
-	 * @throws java.lang.Exception
-	 */
+     */
 	@Override
 	@AfterEach
 	public void tearDown() throws Exception {
@@ -187,10 +185,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#loadPhases()}.
-	 * 
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	// @Ignore("Cannot deserialize objects right now")
 	@Test
 	void testLoadPhases() throws NumberFormatException, IOException {
@@ -213,11 +209,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getPhaseList()}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetPhaseList() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -231,11 +224,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getPhase(java.lang.String)}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetPhaseString() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -247,10 +237,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#saveOneBlockConfig()}.
-	 * 
-	 * @throws NumberFormatException
-	 * @throws IOException 
-	 */
+	 *
+     */
 	@Disabled("Not saving")
 	@Test
 	void testSaveOneBlockConfig() throws NumberFormatException, IOException {
@@ -261,11 +249,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getNextPhase(OneBlockPhase)}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetNextPhase() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -280,9 +265,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#copyPhasesFromAddonJar(java.io.File)}.
-	 * 
-	 * @throws IOException
-	 */
+	 *
+     */
 	@Test
 	void testCopyPhasesFromAddonJar() throws IOException {
 		File dest = new File("dest");
@@ -297,9 +281,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#initBlock(java.lang.String, world.bentobox.aoneblock.oneblocks.OneBlockPhase, org.bukkit.configuration.ConfigurationSection)}.
-	 * 
-	 * @throws IOException
-	 */
+	 *
+     */
 	@Test
 	@Disabled("TODO: fix initBlock test setup to work with new config structure")
 	void testInitBlock() throws IOException {

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlockTest.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlockTest.java
@@ -6,8 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link CraftEngineCustomBlock#fromMap(Map)}.
@@ -30,70 +34,29 @@ class CraftEngineCustomBlockTest {
         assertTrue(result.isEmpty(), "Should return empty when 'id' is missing");
     }
 
-    @Test
-    void fromMapReturnsEmptyWhenIdIsNull() {
+    /**
+     * A present-but-invalid {@code id} value must always yield an empty result.
+     */
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("invalidIdValues")
+    void fromMapReturnsEmptyForInvalidId(Object idValue, String description) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("type", "craftengine");
-        map.put("id", null);
+        map.put("id", idValue);
 
         var result = CraftEngineCustomBlock.fromMap(map);
 
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is null");
+        assertTrue(result.isEmpty(), "Should return empty when " + description);
     }
 
-    @Test
-    void fromMapReturnsEmptyWhenIdIsBlank() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "   ");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is blank");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdIsNonStringValue() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", 42); // integer, not a String
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is not a String");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasNoColon() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "nocolon");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' has no colon");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasEmptyNamespace() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", ":key");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when namespace part is empty");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasEmptyKey() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "namespace:");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when key part is empty");
+    static Stream<Arguments> invalidIdValues() {
+        return Stream.of(
+                Arguments.of(null, "'id' is null"),
+                Arguments.of("   ", "'id' is blank"),
+                Arguments.of(42, "'id' is not a String"),
+                Arguments.of("nocolon", "'id' has no colon"),
+                Arguments.of(":key", "namespace part is empty"),
+                Arguments.of("namespace:", "key part is empty"));
     }
 
     /**


### PR DESCRIPTION
Cleans up the 8 open [SonarCloud issues](https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=BentoBoxWorld_AOneBlock) plus some Javadoc housekeeping. Two logical commits.

## Commit 1 — Javadoc / style housekeeping
- Remove dangling `@param`/`@throws`/`@return` Javadoc tags that have no description across the listener/panel sources and the test suite.
- Replace `'§'` unicode escapes in `PhasesPanel` with the literal `'§'` character (identical value).

## Commit 2 — SonarCloud issues

| Rule | Location | Fix |
|---|---|---|
| **S1192** | `OneBlocksManager` | Extract duplicated `"Fixed block key "` literal into a constant. |
| **S2589** | `CheckPhase.setNewPhase` | `onlinePlayer != null` was always true — `User.getPlayer()` is `@NonNull` and throws for non-players. Guard the call behind `isPlayer()` instead, removing a redundant check **and** a latent throw for owner/NPC users. |
| **S5976** | `CraftEngineCustomBlockTest` | Collapse six near-identical `fromMap` "invalid id" tests into one `@ParameterizedTest` (adds the `junit-jupiter-params` dependency). |
| **S5738** | `CommonTestSetup` | Delete the unused `getPlayerDeathEvent` helper (zero callers) that called a deprecated-for-removal constructor, plus its orphaned imports. |
| **S5738** | `SettingsTest` (×2) | Suppress the rule on the two tests that intentionally exercise deprecated-for-removal `@Override` methods (kept until BentoBox drops them). |
| **S1128** | `AOneBlockTest` | Unused import already removed in commit 1. |
| **S1612** | `CommonTestSetup` | **False positive** — `BaseComponent.toLegacyText` is overloaded (instance `toLegacyText()` + static `toLegacyText(BaseComponent...)`), so a method reference is ambiguous and won't compile. Kept the lambda and marked it `NOSONAR`. |

## Testing
Full suite passes: **430 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)