### PR TITLE
Bump JaCoCo to 0.8.15 for Java 25 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.15</version>
                 <configuration>
                     <append>true</append>
                     <excludes>


### PR DESCRIPTION
JaCoCo 0.8.10 cannot instrument class files produced/generated for Java 25 (class file major version 69). On a Java 25 JVM this produces repeated build noise during tests:

```
Error while instrumenting ... with JaCoCo 0.8.10 ...
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 69
```

Mockito generates its mock classes at the runtime JVM's class-file version, so any test using Mockito triggers it. JaCoCo **0.8.15** bundles ASM 9.10, which supports Java 25.

## Testing
Ran the Mockito-heavy `BlockListenerTest2` **with JaCoCo enabled** — the instrumentation errors are gone and coverage reporting completes. `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)