### PR TITLE
Bump version to 1.25.1 for bug-fix release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.25.0</build.version>
+        <build.version>1.25.1</build.version>
         <!-- SonarCloud -->
         <sonar.projectKey>BentoBoxWorld_AOneBlock</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>


### PR DESCRIPTION
Patch version bump `1.25.0` → `1.25.1` (via `build.version` in `pom.xml`) for the upcoming bug-fix release, which includes the fix for the JetsMinions magic-block NPE (#525).

🤖 Generated with [Claude Code](https://claude.com/claude-code)