### PR TITLE
Release 1.25.1

### DIFF
--- a/.github/workflows/modrinth-publish.yml
+++ b/.github/workflows/modrinth-publish.yml
@@ -89,6 +89,7 @@ jobs:
             1.21.11
             26.1
             26.1.1
+            26.1.2
 
           # Path to the built JAR — Maven produces AOneBlock-<version>.jar in target/
           # Note: glob patterns are not supported; use the release tag directly.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "AOneBlock"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 # AOneBlock — .github/workflows/publish.yml
-# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
-# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
-# the release asset rather than rebuilding from source, so a dependency-repo outage
-# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
+# Publishes the jar attached to a GitHub release to CurseForge and Hangar via the
+# shared BentoBoxWorld/.github reusable workflow. Downloads the release asset instead of
+# rebuilding from source. The reusable workflow is pinned to a commit SHA (Sonar
+# githubactions:S7637). workflow_dispatch lets you (re)publish a given version.
 
-name: Publish release to CurseForge
+name: Publish release to CurseForge and Hangar
 
 on:
   release:
@@ -18,10 +18,10 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@e0c5d98f5e6ef9ea7c9a28afad05f4c07bcde898 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
-      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
+      hangar_slug: "AOneBlock"           # blank = skip Hangar
       curseforge_id: "1512493"
       game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
       version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@71bf927bce32586216baa6995f21852d944b98b9 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@fe4b1f03c19f4fd4212020a06a07a7097923adec # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "AOneBlock"           # blank = skip Hangar

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,30 @@
 # AOneBlock — .github/workflows/publish.yml
-# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+# Publishes the jar attached to a GitHub release to CurseForge (and Hangar once a
+# slug is set) via the shared BentoBoxWorld/.github reusable workflow. It downloads
+# the release asset rather than rebuilding from source, so a dependency-repo outage
+# can't block publishing. Includes workflow_dispatch to (re)publish a given version.
 
-name: Publish release
+name: Publish release to CurseForge
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 1.2.3)"
+        required: true
+        type: string
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@master
     with:
-      hangar_slug: ""
+      use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
+      hangar_slug: ""                    # set the Hangar project slug to enable Hangar publishing
       curseforge_id: "1512493"
-      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+      game_versions: "26.2,26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6,1.21.5"
+      version: ${{ inputs.version }}     # empty on release events -> falls back to the release tag
     secrets:
       HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
       CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+# AOneBlock — .github/workflows/publish.yml
+# CurseForge-first rollout. Hangar left blank; add its slug later to enable Hangar.
+
+name: Publish release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@main
+    with:
+      hangar_slug: ""
+      curseforge_id: "1512493"
+      game_versions: "26.1.2,26.1.1,26.1,1.21.11,1.21.10,1.21.9,1.21.8,1.21.7,1.21.6"
+    secrets:
+      HANGAR_API_KEY: ${{ secrets.HANGAR_API_KEY }}
+      CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
                 <version>5.11.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <!-- Non-minecraft related dependencies -->
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.11.0</mockito.version>
-        <mock-bukkit.version>v1.21-SNAPSHOT</mock-bukkit.version>
+        <mock-bukkit.version>4.110.0</mock-bukkit.version>
         <!-- More visible way how to change dependency versions -->
         <bentobox.version>3.15.0-SNAPSHOT</bentobox.version>
         <items-adder.version>4.0.10</items-adder.version>
@@ -193,8 +193,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.MockBukkit</groupId>
-            <artifactId>MockBukkit</artifactId>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
             <version>${mock-bukkit.version}</version>
             <scope>test</scope>
          </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.15</version>
                 <configuration>
                     <append>true</append>
                     <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.25.0</build.version>
+        <build.version>1.25.1</build.version>
         <!-- SonarCloud -->
         <sonar.projectKey>BentoBoxWorld_AOneBlock</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/aoneblock/AOneBlockPlaceholders.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlockPlaceholders.java
@@ -1,6 +1,5 @@
 package world.bentobox.aoneblock;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -65,29 +64,22 @@ public class AOneBlockPlaceholders {
     }
 
     /**
-     * Get the user's island. Will get either the user's active island, or the island they own.
-     * If they own more than one, then one owned island is picked.
+     * Get the user's owned island. Returns the island owned by the user, not a team
+     * island they may be visiting as a member. If the user owns more than one island,
+     * one is picked.
      * @param user user
-     * @return island
+     * @return island owned by the user, or empty if they own none
      */
     private Optional<Island> getUsersIsland(User user) {
         // Get the active island for the user
         Island i = addon.getIslands().getIsland(addon.getOverWorld(), user);
         if (i != null && i.getOwner() != null && user.getUniqueId().equals(i.getOwner())) {
-            // Owner of this island and currently on this island
-            return Optional.ofNullable(i);
+            // User is the owner of their primary island
+            return Optional.of(i);
         }
 
-        // Check for other owned islands
-        List<Island> ownedIslands = addon.getIslands().getIslands(addon.getOverWorld(), user).stream()
-                .filter(is -> user.getUniqueId().equals(is.getOwner())).toList();
-        if (ownedIslands.size() == 1) {
-            // Replace with the owned island
-            i = ownedIslands.getFirst(); // pick one
-        }
-        // Return what we have found
-        return Optional.ofNullable(i);
-
+        // Find an island the user actually owns (not just a team island they are visiting)
+        return addon.getIslands().getOwnedIslands(addon.getOverWorld(), user).stream().findFirst();
     }
 
     public String getPhaseBlocksNames(User user) {

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -350,8 +350,11 @@ public class BlockListener extends FlagListener implements Listener {
      * @param world - world where the block is being broken
      */
     private void process(@NonNull Cancellable e, @NonNull Island island, @Nullable Player player, @NonNull World world) {
-        // Check if the player has authority to break the magic block
-        if (!checkIsland((@NonNull Event) e, player, island.getCenter(), addon.MAGIC_BLOCK)) {
+        // Check if the player has authority to break the magic block. When there is no
+        // player (e.g. the block is broken by a JetsMinions minion) the protection flag
+        // check is skipped: it requires a User and would otherwise throw an NPE inside
+        // BentoBox's FlagListener. See https://github.com/BentoBoxWorld/AOneBlock/issues/525
+        if (player != null && !checkIsland((@NonNull Event) e, player, island.getCenter(), addon.MAGIC_BLOCK)) {
             // Not allowed
             return;
         }

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -35,7 +35,6 @@ public class CheckPhase {
 
     /**
      * @param addon         AOneBlock
-     * @param blockListener
      */
     public CheckPhase(AOneBlock addon, BlockListener blockListener) {
 	this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/CheckPhase.java
@@ -81,9 +81,10 @@ public class CheckPhase {
 	});
 	// Set the phase name
 	is.setPhaseName(newPhaseName);
-	Player onlinePlayer = user.getPlayer();
-	if (user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld()) && onlinePlayer != null) {
-	    onlinePlayer.showTitle(Title.title(Component.text(newPhaseName), Component.empty()));
+	// user.getPlayer() is @NonNull and throws for non-players, so it must be
+	// called only after isPlayer() has short-circuited.
+	if (user.isPlayer() && user.isOnline() && addon.inWorld(user.getWorld())) {
+	    user.getPlayer().showTitle(Title.title(Component.text(newPhaseName), Component.empty()));
 	}
 	// Run phase start commands
 	Util.runCommands(user,

--- a/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/MakeSpace.java
@@ -40,7 +40,6 @@ public class MakeSpace {
 
 
     /**
-     * @param addon
      */
     public MakeSpace(AOneBlock addon) {
         this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/listeners/WarningSounder.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/WarningSounder.java
@@ -27,7 +27,6 @@ public class WarningSounder {
     private final AOneBlock addon;
 
     /**
-     * @param addon
      */
     public WarningSounder(AOneBlock addon) {
         this.addon = addon;

--- a/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
+++ b/src/main/java/world/bentobox/aoneblock/oneblocks/OneBlocksManager.java
@@ -52,6 +52,7 @@ import world.bentobox.bentobox.util.Util;
 public class OneBlocksManager {
 
     private static final String ONE_BLOCKS_YML = "oneblocks.yml";
+    private static final String FIXED_BLOCK_KEY = "Fixed block key ";
     private static final String NAME = "name";
     private static final String BIOME = "biome";
     private static final String FIRST_BLOCK = "firstBlock";
@@ -292,7 +293,7 @@ public class OneBlocksManager {
         if (customBlock.isPresent()) {
             result.put(k, new OneBlockObject(customBlock.get(), 0));
         } else {
-            addon.logError("Fixed block key " + key + " material is not a valid custom block. Ignoring.");
+            addon.logError(FIXED_BLOCK_KEY + key + " material is not a valid custom block. Ignoring.");
         }
     }
 
@@ -328,7 +329,7 @@ public class OneBlocksManager {
             if (m != null && m.isBlock()) {
                 result.put(k, new OneBlockObject(m, 0));
             } else {
-                addon.logError("Fixed block key " + key + " material is invalid or not a block. Ignoring.");
+                addon.logError(FIXED_BLOCK_KEY + key + " material is invalid or not a block. Ignoring.");
             }
         }
     }
@@ -346,7 +347,7 @@ public class OneBlocksManager {
     private void parseChestWithItem(Map<Integer, OneBlockObject> result, String key, int k, String itemName) {
         Material item = Material.matchMaterial(itemName);
         if (item == null) {
-            addon.logError("Fixed block key " + key + " CHEST_WITH item is invalid: " + itemName + ". Ignoring.");
+            addon.logError(FIXED_BLOCK_KEY + key + " CHEST_WITH item is invalid: " + itemName + ". Ignoring.");
             return;
         }
         Map<Integer, ItemStack> chestContents = new HashMap<>();

--- a/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
+++ b/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
@@ -590,7 +590,7 @@ public class PhasesPanel
         int lastAmpIndex = -2;
 
         while (index < input.length()) {
-            if (input.charAt(index) == '\u00A7' && index < (input.length() - 1)) {
+            if (input.charAt(index) == '§' && index < (input.length() - 1)) {
                 lastAmpIndex = index;
                 activeColor = input.charAt(index + 1);
             }
@@ -608,7 +608,7 @@ public class PhasesPanel
             result.append(input, index, breakPoint).append('\n');
             if (lastAmpIndex >= 0) {
                 // Append color code
-                result.append('\u00A7');
+                result.append('§');
                 result.append(activeColor);
                 result.append(" ");
             }

--- a/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
+++ b/src/test/java/world/bentobox/aoneblock/AOneBlockTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -72,7 +71,6 @@ public class AOneBlockTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override

--- a/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
@@ -27,16 +27,13 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Player.Spigot;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.ItemFactory;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.util.Vector;
-import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -283,7 +280,9 @@ public abstract class CommonTestSetup {
         List<TextComponent> capturedMessages = captor.getAllValues();
 
         // Count the number of occurrences of the expectedMessage in the captured messages
-        long actualOccurrences = capturedMessages.stream().map(component -> component.toLegacyText()) // Convert each TextComponent to plain text
+        // NOSONAR S1612: BaseComponent overloads toLegacyText() (instance) and toLegacyText(BaseComponent...) (static),
+        // so a method reference is ambiguous and will not compile; the lambda is required.
+        long actualOccurrences = capturedMessages.stream().map(component -> component.toLegacyText()) // NOSONAR
                 .filter(messageText -> messageText.contains(expectedMessage)) // Check if the message contains the expected text
                 .count(); // Count how many times the expected message appears
 
@@ -297,13 +296,6 @@ public abstract class CommonTestSetup {
      */
     public EntityExplodeEvent getExplodeEvent(Entity entity, Location l, List<Block> list) {
         return new EntityExplodeEvent(entity, l, list, 0, org.bukkit.ExplosionResult.DESTROY);
-    }
-
-    public PlayerDeathEvent getPlayerDeathEvent(Player player, List<ItemStack> drops, int droppedExp, int newExp,
-            int newTotalExp, int newLevel, @Nullable String deathMessage) {
-        //Technically this null is not allowed, but it works right now
-        return new PlayerDeathEvent(player, null, drops, droppedExp, newExp,
-                newTotalExp, newLevel, deathMessage);
     }
 
 }

--- a/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
+++ b/src/test/java/world/bentobox/aoneblock/CommonTestSetup.java
@@ -242,7 +242,6 @@ public abstract class CommonTestSetup {
     }
 
     /**
-     * @throws Exception
      */
     @AfterEach
     public void tearDown() throws Exception {
@@ -266,7 +265,7 @@ public abstract class CommonTestSetup {
 
     /**
      * Check that spigot sent the message
-     * @param message - message to check
+     * @param expectedMessage - message to check
      */
     public void checkSpigotMessage(String expectedMessage) {
         checkSpigotMessage(expectedMessage, 1);
@@ -295,10 +294,6 @@ public abstract class CommonTestSetup {
 
     /**
      * Get the exploded event
-     * @param entity
-     * @param l
-     * @param list
-     * @return
      */
     public EntityExplodeEvent getExplodeEvent(Entity entity, Location l, List<Block> list) {
         return new EntityExplodeEvent(entity, l, list, 0, org.bukkit.ExplosionResult.DESTROY);

--- a/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
@@ -2,10 +2,13 @@ package world.bentobox.aoneblock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +18,7 @@ import org.mockito.Mock;
 import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
 import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
 import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
 
 /**
  * @author tastybento
@@ -231,6 +235,54 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
         when(im.getIsland(world, user)).thenReturn(null);
         when(im.getIslands(world, user)).thenReturn(List.of());
         assertEquals("", pm.getDoneScale(user));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.aoneblock.AOneBlockPlaceholders#getLifetime(world.bentobox.bentobox.api.user.User)}.
+     */
+    @Test
+    void testGetLifetime() {
+        assertEquals("", pm.getLifetime(user));
+        assertEquals("", pm.getLifetime(null));
+        when(user.getUniqueId()).thenReturn(uuid);
+        // Default setup: island is owned by uuid, getIsland returns island
+        assertEquals("1000", pm.getLifetime(user));
+        // No island found
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(im.getOwnedIslands(world, user)).thenReturn(Set.of());
+        assertEquals("", pm.getLifetime(user));
+    }
+
+    /**
+     * Test that my_island_lifetime_count returns the player's OWN island's count,
+     * not the team island they are currently visiting as a member.
+     */
+    @Test
+    void testGetLifetimeTeamMember() {
+        when(user.getUniqueId()).thenReturn(uuid);
+        // Set up a team island owned by someone else
+        Island teamIsland = mock(Island.class);
+        UUID teamOwnerUUID = UUID.randomUUID();
+        when(teamIsland.getOwner()).thenReturn(teamOwnerUUID);
+        // The user's primary island (via getIsland) is the team island they are visiting
+        when(im.getIsland(world, user)).thenReturn(teamIsland);
+        // The user owns a separate island, returned by getOwnedIslands
+        when(im.getOwnedIslands(world, user)).thenReturn(Set.of(island));
+        // island is the user's own island (owned by uuid), with blockNumber=1000 (lifetime >= blockNumber)
+        assertEquals("1000", pm.getLifetime(user));
+    }
+
+    /**
+     * Test method for {@link world.bentobox.aoneblock.AOneBlockPlaceholders#getLifetimeByLocation(world.bentobox.bentobox.api.user.User)}.
+     */
+    @Test
+    void testGetLifetimeByLocation() {
+        assertEquals("", pm.getLifetimeByLocation(user));
+        assertEquals("", pm.getLifetimeByLocation(null));
+        when(user.getUniqueId()).thenReturn(uuid);
+        assertEquals("1000", pm.getLifetimeByLocation(user));
+        when(im.getProtectedIslandAt(location)).thenReturn(Optional.empty());
+        assertEquals("", pm.getLifetimeByLocation(user));
     }
 
 }

--- a/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
@@ -35,7 +35,6 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
     private OneBlocksManager obm;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/SettingsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/SettingsTest.java
@@ -247,7 +247,8 @@ public class SettingsTest extends CommonTestSetup {
     /**
      * Test method for {@link world.bentobox.aoneblock.Settings#getDefaultIslandFlags()}.
      */
-    @SuppressWarnings("deprecation")
+    // Intentionally exercises a deprecated-for-removal override; keep until BentoBox drops it.
+    @SuppressWarnings({ "deprecation", "removal", "java:S5738" })
     @Test
     void testGetDefaultIslandFlags() {
         assertTrue(s.getDefaultIslandFlags().isEmpty());
@@ -256,7 +257,8 @@ public class SettingsTest extends CommonTestSetup {
     /**
      * Test method for {@link world.bentobox.aoneblock.Settings#getDefaultIslandSettings()}.
      */
-    @SuppressWarnings("deprecation")
+    // Intentionally exercises a deprecated-for-removal override; keep until BentoBox drops it.
+    @SuppressWarnings({ "deprecation", "removal", "java:S5738" })
     @Test
     void testGetDefaultIslandSettings() {
         assertTrue(s.getDefaultIslandSettings().isEmpty());

--- a/src/test/java/world/bentobox/aoneblock/SettingsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/SettingsTest.java
@@ -27,7 +27,6 @@ public class SettingsTest extends CommonTestSetup {
     private Settings s;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -37,7 +36,6 @@ public class SettingsTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandActionBarCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandActionBarCommandTest.java
@@ -38,7 +38,6 @@ class IslandActionBarCommandTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -54,7 +53,6 @@ class IslandActionBarCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandBossBarCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandBossBarCommandTest.java
@@ -41,7 +41,6 @@ class IslandBossBarCommandTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -65,7 +64,6 @@ class IslandBossBarCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandPhasesCommandTest.java
@@ -40,7 +40,6 @@ class IslandPhasesCommandTest extends CommonTestSetup {
     private IslandPhasesCommand ipc;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -61,7 +60,6 @@ class IslandPhasesCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandRespawnBlockCommandTest.java
@@ -48,7 +48,6 @@ class IslandRespawnBlockCommandTest extends CommonTestSetup {
     private @NotNull Block block;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -74,7 +73,6 @@ class IslandRespawnBlockCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommandTest.java
+++ b/src/test/java/world/bentobox/aoneblock/commands/island/IslandSetCountCommandTest.java
@@ -72,7 +72,6 @@ public class IslandSetCountCommandTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override

--- a/src/test/java/world/bentobox/aoneblock/dataobjects/OneBlockIslandsTest.java
+++ b/src/test/java/world/bentobox/aoneblock/dataobjects/OneBlockIslandsTest.java
@@ -28,7 +28,6 @@ public class OneBlockIslandsTest extends CommonTestSetup {
     private String id;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -39,7 +38,6 @@ public class OneBlockIslandsTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest.java
@@ -71,7 +71,6 @@ public class BlockListenerTest extends CommonTestSetup {
     private @NonNull OneBlockPhase phase;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
@@ -9,8 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -70,6 +72,7 @@ import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.data.Money;
+import world.bentobox.bentobox.api.events.island.IslandCreatedEvent;
 import world.bentobox.bentobox.api.user.User;
 import world.bentobox.bentobox.database.AbstractDatabaseHandler;
 import world.bentobox.bentobox.database.DatabaseSetup;
@@ -115,7 +118,6 @@ class BlockListenerTest2 extends CommonTestSetup {
     private MockedStatic<DatabaseSetup> mockDb;
 
     /**
-     * @throws java.lang.Exception
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -1002,6 +1004,31 @@ class BlockListenerTest2 extends CommonTestSetup {
 
         // Not an armor stand → early return, no processing
         verify(im, never()).getIslandAt(any());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakByMinion(EntityInteractEvent)}
+     * Regression test for https://github.com/BentoBoxWorld/AOneBlock/issues/525 —
+     * a minion (armor stand) breaking the magic block has no associated player, so the
+     * protection-flag check must be skipped rather than passing a null player into
+     * BentoBox's FlagListener (which would throw an NPE). The break should be processed
+     * so the magic block respawns.
+     */
+    @Test
+    void testOnBlockBreakByMinionProcessesWithoutPlayer() {
+        when(obm.getPhase(anyInt())).thenReturn(phase);
+
+        EntityInteractEvent e = mock(EntityInteractEvent.class);
+        when(e.getBlock()).thenReturn(magicBlock);
+        when(e.getEntityType()).thenReturn(EntityType.ARMOR_STAND);
+        when(magicBlock.getWorld()).thenReturn(world);
+
+        // Must not throw an NPE from the flag check
+        assertDoesNotThrow(() -> bl.onBlockBreakByMinion(e));
+
+        // Processing proceeded past the (skipped) flag check into phase handling
+        verify(obm, atLeastOnce()).getPhase(anyInt());
     }
 
     /**

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockProtectTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockProtectTest.java
@@ -56,7 +56,6 @@ public class BlockProtectTest extends CommonTestSetup {
     private Block block;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -88,7 +87,6 @@ public class BlockProtectTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/CheckPhaseTest.java
@@ -68,7 +68,6 @@ public class CheckPhaseTest extends CommonTestSetup {
     private Level level;
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -118,7 +117,6 @@ public class CheckPhaseTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach
@@ -266,10 +264,6 @@ public class CheckPhaseTest extends CommonTestSetup {
 
     }
 
-    /**
-     * Test method for
-     * {@link world.bentobox.aoneblock.listeners.BlockListener#replacePlaceholders(org.bukkit.entity.Player, java.lang.String, java.lang.String, world.bentobox.bentobox.database.objects.Island, java.util.List)}.
-     */
     @Test
     void testReplacePlaceholders() {
         // Commands

--- a/src/test/java/world/bentobox/aoneblock/listeners/HoloListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/HoloListenerTest.java
@@ -58,7 +58,6 @@ public class HoloListenerTest extends CommonTestSetup {
 
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/InfoListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/InfoListenerTest.java
@@ -42,7 +42,6 @@ public class InfoListenerTest extends CommonTestSetup {
     private static final UUID ID = UUID.randomUUID();
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/JoinLeaveListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/JoinLeaveListenerTest.java
@@ -34,7 +34,6 @@ public class JoinLeaveListenerTest extends CommonTestSetup {
     private static final UUID ID = UUID.randomUUID();
     private static final Vector VECTOR = new Vector(123,120,456);
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -62,7 +61,6 @@ public class JoinLeaveListenerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/NoBlockHandlerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/NoBlockHandlerTest.java
@@ -39,7 +39,6 @@ public class NoBlockHandlerTest extends CommonTestSetup {
     private BlockListener bl;
  
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -71,7 +70,6 @@ public class NoBlockHandlerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/listeners/StartSafetyListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/StartSafetyListenerTest.java
@@ -46,7 +46,6 @@ public class StartSafetyListenerTest extends CommonTestSetup {
 
     private final @NonNull WSettings ws = new WSettings();
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @BeforeEach
@@ -82,7 +81,6 @@ public class StartSafetyListenerTest extends CommonTestSetup {
     }
 
     /**
-     * @throws java.lang.Exception
      */
     @Override
     @AfterEach

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/OneBlocksManagerTest3.java
@@ -116,8 +116,7 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	}
 
 	/**
-	 * @throws java.lang.Exception
-	 */
+     */
 	@SuppressWarnings("unchecked")
 	@Override
 	@BeforeEach
@@ -154,8 +153,7 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	}
 
 	/**
-	 * @throws java.lang.Exception
-	 */
+     */
 	@Override
 	@AfterEach
 	public void tearDown() throws Exception {
@@ -187,10 +185,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#loadPhases()}.
-	 * 
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	// @Ignore("Cannot deserialize objects right now")
 	@Test
 	void testLoadPhases() throws NumberFormatException, IOException {
@@ -213,11 +209,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getPhaseList()}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetPhaseList() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -231,11 +224,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getPhase(java.lang.String)}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetPhaseString() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -247,10 +237,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#saveOneBlockConfig()}.
-	 * 
-	 * @throws NumberFormatException
-	 * @throws IOException 
-	 */
+	 *
+     */
 	@Disabled("Not saving")
 	@Test
 	void testSaveOneBlockConfig() throws NumberFormatException, IOException {
@@ -261,11 +249,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#getNextPhase(OneBlockPhase)}.
-	 * 
-	 * @throws InvalidConfigurationException
-	 * @throws IOException
-	 * @throws NumberFormatException
-	 */
+	 *
+     */
 	@Test
 	void testGetNextPhase() throws NumberFormatException, IOException {
 		testLoadPhases();
@@ -280,9 +265,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#copyPhasesFromAddonJar(java.io.File)}.
-	 * 
-	 * @throws IOException
-	 */
+	 *
+     */
 	@Test
 	void testCopyPhasesFromAddonJar() throws IOException {
 		File dest = new File("dest");
@@ -297,9 +281,8 @@ public class OneBlocksManagerTest3 extends CommonTestSetup {
 	/**
 	 * Test method for
 	 * {@link world.bentobox.aoneblock.oneblocks.OneBlocksManager#initBlock(java.lang.String, world.bentobox.aoneblock.oneblocks.OneBlockPhase, org.bukkit.configuration.ConfigurationSection)}.
-	 * 
-	 * @throws IOException
-	 */
+	 *
+     */
 	@Test
 	@Disabled("TODO: fix initBlock test setup to work with new config structure")
 	void testInitBlock() throws IOException {

--- a/src/test/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlockTest.java
+++ b/src/test/java/world/bentobox/aoneblock/oneblocks/customblock/CraftEngineCustomBlockTest.java
@@ -6,8 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests for {@link CraftEngineCustomBlock#fromMap(Map)}.
@@ -30,70 +34,29 @@ class CraftEngineCustomBlockTest {
         assertTrue(result.isEmpty(), "Should return empty when 'id' is missing");
     }
 
-    @Test
-    void fromMapReturnsEmptyWhenIdIsNull() {
+    /**
+     * A present-but-invalid {@code id} value must always yield an empty result.
+     */
+    @ParameterizedTest(name = "{1}")
+    @MethodSource("invalidIdValues")
+    void fromMapReturnsEmptyForInvalidId(Object idValue, String description) {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("type", "craftengine");
-        map.put("id", null);
+        map.put("id", idValue);
 
         var result = CraftEngineCustomBlock.fromMap(map);
 
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is null");
+        assertTrue(result.isEmpty(), "Should return empty when " + description);
     }
 
-    @Test
-    void fromMapReturnsEmptyWhenIdIsBlank() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "   ");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is blank");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdIsNonStringValue() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", 42); // integer, not a String
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' is not a String");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasNoColon() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "nocolon");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when 'id' has no colon");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasEmptyNamespace() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", ":key");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when namespace part is empty");
-    }
-
-    @Test
-    void fromMapReturnsEmptyWhenIdHasEmptyKey() {
-        Map<String, Object> map = new LinkedHashMap<>();
-        map.put("type", "craftengine");
-        map.put("id", "namespace:");
-
-        var result = CraftEngineCustomBlock.fromMap(map);
-
-        assertTrue(result.isEmpty(), "Should return empty when key part is empty");
+    static Stream<Arguments> invalidIdValues() {
+        return Stream.of(
+                Arguments.of(null, "'id' is null"),
+                Arguments.of("   ", "'id' is blank"),
+                Arguments.of(42, "'id' is not a String"),
+                Arguments.of("nocolon", "'id' has no colon"),
+                Arguments.of(":key", "namespace part is empty"),
+                Arguments.of("namespace:", "key part is empty"));
     }
 
     /**

--- a/src/test/java/world/bentobox/aoneblock/panels/PhasesPanelTest.java
+++ b/src/test/java/world/bentobox/aoneblock/panels/PhasesPanelTest.java
@@ -1,0 +1,2576 @@
+package world.bentobox.aoneblock.panels;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+
+import world.bentobox.aoneblock.AOneBlock;
+import world.bentobox.aoneblock.CommonTestSetup;
+import world.bentobox.aoneblock.Settings;
+import world.bentobox.aoneblock.dataobjects.OneBlockIslands;
+import world.bentobox.aoneblock.listeners.BlockListener;
+import world.bentobox.aoneblock.oneblocks.OneBlockPhase;
+import world.bentobox.aoneblock.oneblocks.OneBlocksManager;
+import world.bentobox.aoneblock.oneblocks.Requirement;
+import world.bentobox.aoneblock.oneblocks.Requirement.ReqType;
+import world.bentobox.bank.Bank;
+import world.bentobox.bank.BankManager;
+import world.bentobox.bank.data.Money;
+import world.bentobox.bentobox.api.panels.TemplatedPanel;
+import world.bentobox.bentobox.api.panels.reader.ItemTemplateRecord;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.hooks.LangUtilsHook;
+import world.bentobox.bentobox.util.Util;
+import world.bentobox.level.Level;
+
+/**
+ * Comprehensive tests for PhasesPanel covering all methods and branches.
+ */
+class PhasesPanelTest extends CommonTestSetup {
+
+    @Mock
+    private AOneBlock addon;
+    @Mock
+    private OneBlocksManager oneBlockManager;
+    @Mock
+    private BlockListener blockListener;
+    @Mock
+    private Settings addonSettings;
+    @Mock
+    private Bank bank;
+    @Mock
+    private Level level;
+
+    private PhasesPanel panel;
+
+    private void setUpAddonMocks() {
+        when(addon.getPlugin()).thenReturn(plugin);
+        when(addon.getOneBlockManager()).thenReturn(oneBlockManager);
+        when(addon.getIslandsManager()).thenReturn(im);
+        when(addon.getBlockListener()).thenReturn(blockListener);
+        when(addon.getSettings()).thenReturn(addonSettings);
+        when(addonSettings.getSetCountCommand()).thenReturn("setcount 0");
+        when(addon.getPlayerCommand()).thenReturn(Optional.empty());
+    }
+
+    private OneBlockPhase createTestPhase(String phaseName) {
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName(phaseName);
+        phase.addBlock(Material.STONE, 100);
+        phase.addBlock(Material.DIRT, 50);
+        return phase;
+    }
+
+    private OneBlockPhase createTestPhaseWithRequirements(String phaseName) {
+        OneBlockPhase phase = createTestPhase(phaseName);
+        List<Requirement> reqs = new ArrayList<>();
+        reqs.add(new Requirement(ReqType.ECO, 100.0));
+        reqs.add(new Requirement(ReqType.BANK, 50.0));
+        reqs.add(new Requirement(ReqType.LEVEL, 10L));
+        reqs.add(new Requirement(ReqType.PERMISSION, "permission.test"));
+        reqs.add(new Requirement(ReqType.COOLDOWN, 60L));
+        phase.setRequirements(reqs);
+        return phase;
+    }
+
+    private NavigableMap<Integer, OneBlockPhase> createBlockProbs() {
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        OneBlockPhase phase1 = createTestPhase("Plains");
+        probs.put(0, phase1);
+        return probs;
+    }
+
+    // =========================================================================
+    // Test insertNewlines (static method)
+    // =========================================================================
+
+    /**
+     * Test insertNewlines with short string that doesn't need wrapping.
+     */
+    @Test
+    void testInsertNewlinesShortString() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "short";
+        String result = (String) method.invoke(null, input, 50);
+
+        assertEquals("short", result);
+    }
+
+    /**
+     * Test insertNewlines with long string that needs wrapping at space.
+     */
+    @Test
+    void testInsertNewlinesLongStringWithSpaces() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "This is a very long string that should be wrapped at the interval";
+        String result = (String) method.invoke(null, input, 20);
+
+        assertTrue(result.contains("\n"));
+    }
+
+    /**
+     * Test insertNewlines with long string without spaces (no wrapping possible).
+     */
+    @Test
+    void testInsertNewlinesLongStringNoSpaces() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz";
+        String result = (String) method.invoke(null, input, 20);
+
+        assertTrue(result.contains("\n"));
+    }
+
+    /**
+     * Test insertNewlines with color codes (§).
+     */
+    @Test
+    void testInsertNewlinesWithColorCode() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "§cThis is a colored string that should wrap correctly when color codes are present";
+        String result = (String) method.invoke(null, input, 20);
+
+        // Should preserve or re-apply color codes
+        assertTrue(result.contains("§"));
+    }
+
+    // =========================================================================
+    // Test parseWrapAt
+    // =========================================================================
+
+    /**
+     * Test parseWrapAt with valid number.
+     */
+    @Test
+    void testParseWrapAtValid() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("30");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("parseWrapAt");
+        method.setAccessible(true);
+
+        int result = (int) method.invoke(panel);
+
+        assertEquals(30, result);
+    }
+
+    /**
+     * Test parseWrapAt with invalid number (non-numeric).
+     */
+    @Test
+    void testParseWrapAtInvalid() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("not-a-number");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("parseWrapAt");
+        method.setAccessible(true);
+
+        int result = (int) method.invoke(panel);
+
+        assertEquals(50, result); // default
+        verify(addon).logError(anyString());
+    }
+
+    // =========================================================================
+    // Test getMaterialName
+    // =========================================================================
+
+    /**
+     * Test getMaterialName when LangUtils hook is present.
+     */
+    @Test
+    void testGetMaterialNameWithLangUtils() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.of(mock(LangUtilsHook.class)));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("getMaterialName", User.class, Material.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, user, Material.STONE);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test getMaterialName when LangUtils hook is absent.
+     */
+    @Test
+    void testGetMaterialNameWithoutLangUtils() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText("STONE")).thenReturn("Stone");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("getMaterialName", User.class, Material.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, user, Material.STONE);
+
+        assertEquals("Stone", result);
+    }
+
+    // =========================================================================
+    // Test buildRequirementsText
+    // =========================================================================
+
+    /**
+     * Test buildRequirementsText with LEVEL requirement.
+     */
+    @Test
+    void testBuildRequirementsTextAllTypes() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.LEVEL, 10L)));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildRequirementsText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, phase);
+
+        assertNotNull(result);
+    }
+
+    // =========================================================================
+    // Test buildBlocksText
+    // =========================================================================
+
+    /**
+     * Test buildBlocksText with phase blocks.
+     */
+    @Test
+    void testBuildBlocksText() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks", "name", "Stone")).thenReturn("Stone, ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks", "name", "Dirt")).thenReturn("Dirt, ");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildBlocksText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, phase);
+
+        assertNotNull(result);
+        assertTrue(result.contains("Block"));
+    }
+
+    // =========================================================================
+    // Test applyIcon
+    // =========================================================================
+
+    /**
+     * Test applyIcon with template icon non-null.
+     */
+    @Test
+    void testApplyIconWithTemplateIcon() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        ItemStack icon = new ItemStack(Material.APPLE);
+        ItemTemplateRecord template = new ItemTemplateRecord(icon, null, null, null, Map.of(), null);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("applyIcon",
+                world.bentobox.bentobox.api.panels.builders.PanelItemBuilder.class,
+                ItemTemplateRecord.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.builders.PanelItemBuilder builder = new world.bentobox.bentobox.api.panels.builders.PanelItemBuilder();
+        method.invoke(panel, builder, template, phase);
+
+        assertNotNull(builder.getIcon());
+    }
+
+    /**
+     * Test applyIcon with null template icon and null phase first block.
+     */
+    @Test
+    void testApplyIconNullTemplateNullFirstBlock() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, null, Map.of(), null);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("applyIcon",
+                world.bentobox.bentobox.api.panels.builders.PanelItemBuilder.class,
+                ItemTemplateRecord.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.builders.PanelItemBuilder builder = new world.bentobox.bentobox.api.panels.builders.PanelItemBuilder();
+        method.invoke(panel, builder, template, phase);
+
+        assertNotNull(builder.getIcon());
+    }
+
+    // =========================================================================
+    // Test applyTitle
+    // =========================================================================
+
+    /**
+     * Test applyTitle with null template title.
+     */
+    @Test
+    void testApplyTitleNullTemplateTitle() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, null, Map.of(), null);
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.name", "[phase]", "Plains")).thenReturn("Plains Phase");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("applyTitle",
+                world.bentobox.bentobox.api.panels.builders.PanelItemBuilder.class,
+                ItemTemplateRecord.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.builders.PanelItemBuilder builder = new world.bentobox.bentobox.api.panels.builders.PanelItemBuilder();
+        method.invoke(panel, builder, template, phase);
+
+        assertNotNull(builder.getName());
+    }
+
+    /**
+     * Test applyTitle with non-null template title.
+     */
+    @Test
+    void testApplyTitleWithTemplateTitle() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        ItemTemplateRecord template = new ItemTemplateRecord(null, "custom.title", null, null, Map.of(), null);
+
+        when(user.getTranslation(world, "custom.title", "[phase]", "Plains")).thenReturn("Custom Title");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("applyTitle",
+                world.bentobox.bentobox.api.panels.builders.PanelItemBuilder.class,
+                ItemTemplateRecord.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.builders.PanelItemBuilder builder = new world.bentobox.bentobox.api.panels.builders.PanelItemBuilder();
+        method.invoke(panel, builder, template, phase);
+
+        assertNotNull(builder.getName());
+    }
+
+    // =========================================================================
+    // Test canApplyPhase
+    // =========================================================================
+
+    /**
+     * Test canApplyPhase returns false when island is null.
+     */
+    @Test
+    void testCanApplyPhaseIslandNull() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertFalse(result);
+    }
+
+    /**
+     * Test canApplyPhase returns false when oneBlockIsland is null.
+     */
+    @Test
+    void testCanApplyPhaseOneBlockIslandNull() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertFalse(result);
+    }
+
+    /**
+     * Test canApplyPhase returns true when all conditions pass.
+     */
+    @Test
+    void testCanApplyPhaseSuccess() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(100L);
+        oneBlockIsland.setLastPhaseChangeTime(System.currentTimeMillis());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertTrue(result);
+    }
+
+    // =========================================================================
+    // Test phaseRequirementsFail
+    // =========================================================================
+
+    /**
+     * Test phaseRequirementsFail with LEVEL requirement passing.
+     */
+    @Test
+    void testPhaseRequirementsFailLevelPass() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.LEVEL, 10L)));
+
+        when(addon.getAddonByName("Level")).thenReturn(Optional.of(level));
+        when(level.isEnabled()).thenReturn(true);
+        when(level.getIslandLevel(world, testIsland.getOwner())).thenReturn(100L);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // Level is 100, requirement is 10, so it passes
+    }
+
+    /**
+     * Test phaseRequirementsFail with BANK requirement failing.
+     */
+    @Test
+    void testPhaseRequirementsFailBankFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.BANK, 100000.0)));
+
+        BankManager bm = mock(BankManager.class);
+        when(bank.getBankManager()).thenReturn(bm);
+        when(bm.getBalance(testIsland)).thenReturn(new Money(10.0)); // Low balance
+        when(bank.isEnabled()).thenReturn(true);
+        when(addon.getAddonByName("Bank")).thenReturn(Optional.of(bank));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertTrue(result); // Bank is 10, requirement is 100000, so it fails
+    }
+
+    /**
+     * Test phaseRequirementsFail with PERMISSION requirement.
+     */
+    @Test
+    void testPhaseRequirementsFailPermissionFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.PERMISSION, "admin.phase")));
+
+        when(user.hasPermission("admin.phase")).thenReturn(false);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertTrue(result); // User doesn't have permission, so it fails
+    }
+
+    /**
+     * Test phaseRequirementsFail with COOLDOWN requirement.
+     */
+    @Test
+    void testPhaseRequirementsFailCooldownPass() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLastPhaseChangeTime(System.currentTimeMillis() - 120000); // 2 minutes ago
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.COOLDOWN, 60L))); // 60 second cooldown
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // Cooldown has passed
+    }
+
+    // =========================================================================
+    // Test collectTooltips
+    // =========================================================================
+
+    /**
+     * Test collectTooltips with null and blank tooltips.
+     */
+    @Test
+    void testCollectTooltipsNullAndBlank() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        List<ItemTemplateRecord.ActionRecords> actions = List.of(
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "content", null),
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "content", ""),
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "content", "   ")
+        );
+
+        when(user.getTranslation(world, "")).thenReturn("");
+        when(user.getTranslation(world, "   ")).thenReturn("   ");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("collectTooltips", List.class);
+        method.setAccessible(true);
+
+        List<String> result = (List<String>) method.invoke(panel, actions);
+
+        assertEquals(0, result.size()); // All tooltips are null or blank
+    }
+
+    /**
+     * Test collectTooltips with real tooltip.
+     */
+    @Test
+    void testCollectTooltipsWithRealTooltip() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        List<ItemTemplateRecord.ActionRecords> actions = List.of(
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "content", "tooltip.key")
+        );
+
+        when(user.getTranslation(world, "tooltip.key")).thenReturn("Real tooltip");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("collectTooltips", List.class);
+        method.setAccessible(true);
+
+        List<String> result = (List<String>) method.invoke(panel, actions);
+
+        assertEquals(1, result.size());
+        assertEquals("Real tooltip", result.get(0));
+    }
+
+    // =========================================================================
+    // Test createNextButton
+    // =========================================================================
+
+    /**
+     * Test createNextButton returns null when no next page.
+     */
+    @Test
+    void testCreateNextButtonNoNextPage() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // Set pageIndex to 0
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc", null, Map.of("PHASE", 1), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNull(result); // Only 1 phase, so no next page
+    }
+
+    /**
+     * Test createNextButton returns button with indexing.
+     */
+    @Test
+    void testCreateNextButtonWithIndexing() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // Set pageIndex to 0
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        when(user.getTranslation(world, "title")).thenReturn("Next Page");
+        when(user.getTranslation(world, "desc", "number", "2")).thenReturn("Page 2");
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc", List.of(), Map.of("INDEXING", true), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    // =========================================================================
+    // Test createPreviousButton
+    // =========================================================================
+
+    /**
+     * Test createPreviousButton returns null when pageIndex is 0.
+     */
+    @Test
+    void testCreatePreviousButtonPageIndexZero() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // pageIndex is already 0 by default
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc", List.of(), Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNull(result);
+    }
+
+    /**
+     * Test createPreviousButton returns button when pageIndex > 0.
+     */
+    @Test
+    void testCreatePreviousButtonPageIndexPositive() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // Set pageIndex to 1
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 1);
+
+        when(user.getTranslation(world, "title")).thenReturn("Previous Page");
+        when(user.getTranslation(world, "desc", "number", "1")).thenReturn("Page 1");
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc", List.of(), Map.of("INDEXING", true), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    // =========================================================================
+    // Test createPhaseButton (with slot)
+    // =========================================================================
+
+    /**
+     * Test createPhaseButton with slot returns null when elementList is empty.
+     */
+    @Test
+    void testCreatePhaseButtonSlotEmptyList() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(new TreeMap<>()); // Empty
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, List.of(), Map.of(), null);
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNull(result);
+    }
+
+    /**
+     * Test createPhaseButton with slot returns null when index >= size.
+     */
+    @Test
+    void testCreatePhaseButtonSlotOutOfIndex() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs()); // 1 phase
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, List.of(), Map.of(), null);
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+        when(slot.slot()).thenReturn(5); // Out of index
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNull(result);
+    }
+
+    // =========================================================================
+    // Test createPhaseButton (with entry)
+    // =========================================================================
+
+    /**
+     * Test createPhaseButton with null entry returns null.
+     */
+    @Test
+    void testCreatePhaseButtonEntryNull() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, List.of(), Map.of(), null);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, (Object) null);
+
+        assertNull(result);
+    }
+
+    /**
+     * Test createPhaseButton with null phase value returns null.
+     */
+    @Test
+    void testCreatePhaseButtonEntryNullValue() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, List.of(), Map.of(), null);
+        @SuppressWarnings("unchecked")
+        Map.Entry<Integer, OneBlockPhase> entry = mock(Map.Entry.class);
+        when(entry.getValue()).thenReturn(null);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, entry);
+
+        assertNull(result);
+    }
+
+    // =========================================================================
+    // Test runCommandCall
+    // =========================================================================
+
+    /**
+     * Test runCommandCall with empty playerCommand.
+     */
+    @Test
+    void testRunCommandCallNoPlayerCommand() throws Exception {
+        setUpAddonMocks();
+        when(addon.getPlayerCommand()).thenReturn(Optional.empty());
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("runCommandCall", String.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        // Should not throw - playerCommand is empty so nothing happens beyond closeInventory
+        method.invoke(panel, "setcount", phase);
+    }
+
+    // =========================================================================
+    // Test build
+    // =========================================================================
+
+    /**
+     * Test build with empty elementList.
+     */
+    @Test
+    void testBuildEmptyElementList() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(new TreeMap<>()); // Empty
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(addon.getDescription()).thenReturn(mock());
+        when(addon.getDescription().getName()).thenReturn("AOneBlock");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("build");
+        method.setAccessible(true);
+
+        method.invoke(panel);
+
+        verify(addon).logError("There are no available phases for selection!");
+    }
+
+    // =========================================================================
+    // Test openPanel (public static)
+    // =========================================================================
+
+    /**
+     * Test openPanel public method with empty phases.
+     */
+    @Test
+    void testOpenPanelEmptyPhases() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(new TreeMap<>()); // Empty
+        when(addon.getDescription()).thenReturn(mock());
+        when(addon.getDescription().getName()).thenReturn("AOneBlock");
+
+        PhasesPanel.openPanel(addon, world, user);
+
+        verify(addon).logError("There are no available phases for selection!");
+    }
+
+    // =========================================================================
+    // Additional coverage tests
+    // =========================================================================
+
+    /**
+     * Test buildBlocksText with trim.
+     */
+    @Test
+    void testBuildBlocksTextWithTrim() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks", "name", "Stone")).thenReturn("Stone, ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.blocks", "name", "Dirt")).thenReturn("Dirt\n"); // Has newline
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildBlocksText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, phase);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test applyIcon with phase icon block present.
+     */
+    @Test
+    void testApplyIconWithPhaseIconBlock() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        ItemStack phaseIcon = new ItemStack(Material.DIAMOND);
+        phase.setIconBlock(phaseIcon);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, null, Map.of(), null);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("applyIcon",
+                world.bentobox.bentobox.api.panels.builders.PanelItemBuilder.class,
+                ItemTemplateRecord.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.builders.PanelItemBuilder builder = new world.bentobox.bentobox.api.panels.builders.PanelItemBuilder();
+        method.invoke(panel, builder, template, phase);
+
+        assertNotNull(builder.getIcon());
+    }
+
+    /**
+     * Test createPhaseButton (with entry) with valid phase.
+     */
+    @Test
+    void testCreatePhaseButtonEntryValid() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(new OneBlockIslands(testIsland.getUniqueId()));
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        Map.Entry<Integer, OneBlockPhase> entry = Map.entry(0, phase);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "description", List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "cmd", "tooltip")),
+                Map.of(), null);
+
+        when(user.getTranslation(world, "title", "[phase]", "Plains")).thenReturn("Plains");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(user.getTranslation(world, "tooltip")).thenReturn("Click to select");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, entry);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test createNextButton with title and description null.
+     */
+    @Test
+    void testCreateNextButtonNullTitleDesc() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        // Template with null title and description
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                null, null, List.of(), Map.of("INDEXING", false), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test createPreviousButton with no icon.
+     */
+    @Test
+    void testCreatePreviousButtonNoIcon() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 1);
+
+        // Template with null icon
+        ItemTemplateRecord template = new ItemTemplateRecord(null,
+                "title", "desc", List.of(), Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test phaseRequirementsFail with no requirements.
+     */
+    @Test
+    void testPhaseRequirementsFailNoRequirements() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of()); // No requirements
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // No requirements, so doesn't fail
+    }
+
+    /**
+     * Test canApplyPhase with requirements failing.
+     */
+    @Test
+    void testCanApplyPhaseRequirementsFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(100L);
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.PERMISSION, "admin.phase")));
+
+        when(user.hasPermission("admin.phase")).thenReturn(false);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertFalse(result); // Requirement fails, so can't apply phase
+    }
+
+    /**
+     * Test phaseRequirementsFail with LEVEL requirement failing.
+     */
+    @Test
+    void testPhaseRequirementsFailLevelFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.LEVEL, 1000L)));
+
+        when(addon.getAddonByName("Level")).thenReturn(Optional.of(level));
+        when(level.isEnabled()).thenReturn(true);
+        when(level.getIslandLevel(world, testIsland.getOwner())).thenReturn(10L); // Low level
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertTrue(result); // Level is 10, requirement is 1000, so it fails
+    }
+
+    /**
+     * Test collectTooltips with only blank tooltips.
+     */
+    @Test
+    void testCollectTooltipsAllBlank() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        List<ItemTemplateRecord.ActionRecords> actions = List.of(
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "content", "tooltip1"),
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "VIEW", "content", "tooltip2")
+        );
+
+        when(user.getTranslation(world, "tooltip1")).thenReturn("   "); // Blank after translation
+        when(user.getTranslation(world, "tooltip2")).thenReturn(""); // Empty
+
+        Method method = PhasesPanel.class.getDeclaredMethod("collectTooltips", List.class);
+        method.setAccessible(true);
+
+        List<String> result = (List<String>) method.invoke(panel, actions);
+
+        assertEquals(0, result.size()); // All translated to blank
+    }
+
+    /**
+     * Test insertNewlines with exact boundary.
+     */
+    @Test
+    void testInsertNewlinesExactBoundary() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "123456789"; // 9 chars - exactly boundary - 1
+        String result = (String) method.invoke(null, input, 10);
+
+        assertEquals("123456789", result); // No wrap needed
+    }
+
+    /**
+     * Test phaseRequirementsFail with ECO requirement failing.
+     */
+    @Test
+    void testPhaseRequirementsFailEcoFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.ECO, 10000.0)));
+
+        // Don't mock vault - it returns empty Optional, so eco check fails (returns false)
+        when(addon.getPlugin().getVault()).thenReturn(Optional.empty());
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // Vault empty means requirement check passes
+    }
+
+    /**
+     * Test buildClickHandler with VIEW action.
+     */
+    @Test
+    void testBuildClickHandlerViewAction() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(new OneBlockIslands(testIsland.getUniqueId()));
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        List<ItemTemplateRecord.ActionRecords> actions = List.of(
+                new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "VIEW", "content", null)
+        );
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildClickHandler", List.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, actions, phase);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test createPhaseButton with VIEW action (no SELECT).
+     */
+    @Test
+    void testCreatePhaseButtonViewOnly() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(new OneBlockIslands(testIsland.getUniqueId()));
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        Map.Entry<Integer, OneBlockPhase> entry = Map.entry(0, phase);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "description",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "VIEW", "cmd", null)),
+                Map.of(), null);
+
+        when(user.getTranslation(world, "title", "[phase]", "Plains")).thenReturn("Plains");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, entry);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test phaseRequirementsFail with COOLDOWN requirement failing.
+     */
+    @Test
+    void testPhaseRequirementsFailCooldownFail() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLastPhaseChangeTime(System.currentTimeMillis()); // Just now
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.COOLDOWN, 300L))); // 5 minute cooldown
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertTrue(result); // Cooldown not yet elapsed
+    }
+
+    /**
+     * Test createNextButton with actions that don't match.
+     */
+    @Test
+    void testCreateNextButtonActionsNoMatch() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        // Action that doesn't match NEXT
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "PREVIOUS", "content", null)),
+                Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result); // Action doesn't match, but button is still created
+    }
+
+    /**
+     * Test createPreviousButton with actions that don't match.
+     */
+    @Test
+    void testCreatePreviousButtonActionsNoMatch() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 1);
+
+        // Action that doesn't match PREVIOUS
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "NEXT", "content", null)),
+                Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result); // Action doesn't match, but button is still created
+    }
+
+    /**
+     * Test getMaterialName with different material.
+     */
+    @Test
+    void testGetMaterialNameDifferentMaterial() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText("DIAMOND_BLOCK")).thenReturn("Diamond Block");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("getMaterialName", User.class, Material.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, user, Material.DIAMOND_BLOCK);
+
+        assertEquals("Diamond Block", result);
+    }
+
+    /**
+     * Test createPhaseButton slot with valid index.
+     */
+    @Test
+    void testCreatePhaseButtonSlotValidIndex() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(new OneBlockIslands(testIsland.getUniqueId()));
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        OneBlockPhase phase = createTestPhase("Phase1");
+        probs.put(0, phase);
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "description", List.of(), Map.of(), null);
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+        when(slot.slot()).thenReturn(0);
+
+        when(user.getTranslation(world, "title", "[phase]", "Phase1")).thenReturn("Phase1");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test insertNewlines with long string with exact space at interval.
+     */
+    @Test
+    void testInsertNewlinesSpaceAtInterval() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "word1 word2 word3 word4";
+        String result = (String) method.invoke(null, input, 6);
+
+        assertTrue(result.contains("\n"));
+    }
+
+    /**
+     * Test parseWrapAt returns correct value from translation.
+     */
+    @Test
+    void testParseWrapAtReturnsTranslatedValue() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("75");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("parseWrapAt");
+        method.setAccessible(true);
+
+        int result = (int) method.invoke(panel);
+
+        assertEquals(75, result);
+    }
+
+    /**
+     * Test phaseRequirementsFail with PERMISSION requirement passing.
+     */
+    @Test
+    void testPhaseRequirementsFailPermissionPass() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.PERMISSION, "admin.phase")));
+
+        when(user.hasPermission("admin.phase")).thenReturn(true);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // User has permission, so it passes
+    }
+
+    /**
+     * Test buildNextButton with UNKNOWN click type (always matches).
+     */
+    @Test
+    void testCreateNextButtonUnknownClickType() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        // Action with UNKNOWN click type (should match any click)
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.UNKNOWN, "NEXT", "content", null)),
+                Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test insertNewlines with no spaces in long text.
+     */
+    @Test
+    void testInsertNewlinesNoSpacesLongText() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        String input = "verylongwordwithoutanyspacesinit";
+        String result = (String) method.invoke(null, input, 10);
+
+        assertTrue(result.contains("\n"));
+    }
+
+    /**
+     * Test canApplyPhase with block number >= lifetime.
+     */
+    @Test
+    void testCanApplyPhaseBlockNumberHigherThanLifetime() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(5L); // Small lifetime
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("100");
+        phase.setPhaseName("HighBlock");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertFalse(result); // Block 100 >= lifetime 5, so cannot apply
+    }
+
+    /**
+     * Test phaseRequirementsFail with BANK requirement passing.
+     */
+    @Test
+    void testPhaseRequirementsFailBankPass() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.BANK, 50.0)));
+
+        BankManager bm = mock(BankManager.class);
+        when(bank.getBankManager()).thenReturn(bm);
+        when(bm.getBalance(testIsland)).thenReturn(new Money(1000.0)); // Plenty of balance
+        when(bank.isEnabled()).thenReturn(true);
+        when(addon.getAddonByName("Bank")).thenReturn(Optional.of(bank));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // Bank balance is sufficient
+    }
+
+    /**
+     * Test phaseRequirementsFail with LEVEL addon not enabled.
+     */
+    @Test
+    void testPhaseRequirementsFailLevelNotEnabled() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("TestPhase");
+        phase.setRequirements(List.of(new Requirement(ReqType.LEVEL, 100L)));
+
+        when(addon.getAddonByName("Level")).thenReturn(Optional.empty()); // Addon not present
+
+        Method method = PhasesPanel.class.getDeclaredMethod("phaseRequirementsFail", OneBlockPhase.class, OneBlockIslands.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase, oneBlockIsland);
+
+        assertFalse(result); // Addon not present, so returns false (doesn't fail)
+    }
+
+    // =========================================================================
+    // High-coverage targeted tests to hit missed lines (90%+ goal)
+    // =========================================================================
+
+    /**
+     * Test buildRequirementsText with actual requirement iteration (L432-441).
+     * Tests all requirement switch branches.
+     */
+    @Test
+    void testBuildRequirementsTextAllBranches() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // Create phase with all requirement types
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("AllReqs");
+        phase.setRequirements(List.of(
+            new Requirement(ReqType.ECO, 100.0),
+            new Requirement(ReqType.BANK, 50.0),
+            new Requirement(ReqType.LEVEL, 10L),
+            new Requirement(ReqType.PERMISSION, "test.perm"),
+            new Requirement(ReqType.COOLDOWN, 60L)
+        ));
+
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.economy")).thenReturn("Econ: ");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.bank")).thenReturn("Bank: ");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.level")).thenReturn("Level: ");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.permission")).thenReturn("Perm: ");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildRequirementsText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        Object reqTexts = method.invoke(panel, phase);
+
+        assertNotNull(reqTexts);
+        // Get fields via reflection to verify they're populated
+        Field bankField = reqTexts.getClass().getDeclaredField("bank");
+        Field economyField = reqTexts.getClass().getDeclaredField("economy");
+        Field levelField = reqTexts.getClass().getDeclaredField("level");
+        Field permissionField = reqTexts.getClass().getDeclaredField("permission");
+        bankField.setAccessible(true);
+        economyField.setAccessible(true);
+        levelField.setAccessible(true);
+        permissionField.setAccessible(true);
+
+        assertNotNull(bankField.get(reqTexts));
+        assertNotNull(economyField.get(reqTexts));
+        assertNotNull(levelField.get(reqTexts));
+        assertNotNull(permissionField.get(reqTexts));
+    }
+
+    /**
+     * Test buildDescriptionText with templated path and null biome (L488-511).
+     */
+    @Test
+    void testBuildDescriptionTextTemplatedNullBiome() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        phase.setPhaseBiome(null);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, "custom.desc", List.of(), Map.of(), null);
+
+        // Create RequirementTexts via reflection
+        Class<?> reqTextClass = Class.forName("world.bentobox.aoneblock.panels.PhasesPanel$RequirementTexts");
+        java.lang.reflect.Constructor<?> reqConstructor = reqTextClass.getDeclaredConstructor(String.class, String.class, String.class, String.class);
+        reqConstructor.setAccessible(true);
+        Object reqTexts = reqConstructor.newInstance("", "", "", "");
+
+        when(user.getTranslationOrNothing("custom.desc", "number", "0", "[biome]", "", "[bank]", "", "[economy]", "", "[level]", "", "[permission]", "", "[blocks]", ""))
+            .thenReturn("Description");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildDescriptionText", ItemTemplateRecord.class, OneBlockPhase.class, reqTextClass, String.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, template, phase, reqTexts, "");
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test buildDescriptionText with templated path and non-null biome (L501).
+     */
+    @Test
+    void testBuildDescriptionTextTemplatedWithBiome() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("BiomePhase");
+        phase.addBlock(Material.GRASS_BLOCK, 100);
+        // Mock a biome object
+        org.bukkit.block.Biome biome = mock(org.bukkit.block.Biome.class);
+        phase.setPhaseBiome(biome);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, "custom.desc", List.of(), Map.of(), null);
+
+        Class<?> reqTextClass = Class.forName("world.bentobox.aoneblock.panels.PhasesPanel$RequirementTexts");
+        java.lang.reflect.Constructor<?> reqConstructor = reqTextClass.getDeclaredConstructor(String.class, String.class, String.class, String.class);
+        reqConstructor.setAccessible(true);
+        Object reqTexts = reqConstructor.newInstance("", "", "", "");
+
+        try (MockedStatic<LangUtilsHook> ms = mockStatic(LangUtilsHook.class)) {
+            ms.when(() -> LangUtilsHook.getBiomeName(biome, user)).thenReturn("Plains");
+
+            when(user.getTranslationOrNothing("custom.desc", "number", "0", "[biome]", "Plains", "[bank]", "", "[economy]", "", "[level]", "", "[permission]", "", "[blocks]", ""))
+                .thenReturn("Plains Description");
+
+            Method method = PhasesPanel.class.getDeclaredMethod("buildDescriptionText", ItemTemplateRecord.class, OneBlockPhase.class, reqTextClass, String.class);
+            method.setAccessible(true);
+
+            String result = (String) method.invoke(panel, template, phase, reqTexts, "");
+
+            assertNotNull(result);
+            assertTrue(result.contains("Plains"));
+        }
+    }
+
+    /**
+     * Test buildDefaultDescription path (L516-531).
+     */
+    @Test
+    void testBuildDefaultDescription() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        phase.setPhaseBiome(null);
+
+        Class<?> reqTextClass = Class.forName("world.bentobox.aoneblock.panels.PhasesPanel$RequirementTexts");
+        java.lang.reflect.Constructor<?> reqConstructor = reqTextClass.getDeclaredConstructor(String.class, String.class, String.class, String.class);
+        reqConstructor.setAccessible(true);
+        Object reqTexts = reqConstructor.newInstance("", "", "", "");
+
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.starting-block", "number", "0")).thenReturn("Block 0");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.description", "[starting-block]", "Block 0", "[biome]", "", "[bank]", "", "[economy]", "", "[level]", "", "[permission]", "", "[blocks]", ""))
+            .thenReturn("Default Desc");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildDefaultDescription", OneBlockPhase.class, reqTextClass, String.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, phase, reqTexts, "");
+
+        assertNotNull(result);
+        assertTrue(result.contains("Default"));
+    }
+
+    /**
+     * Test runCommandCall with playerCommand present (L660-L669).
+     */
+    @Test
+    void testRunCommandCallWithPlayerCommand() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        // Mock command structure - but playerCommand returns empty since we want the alternative path
+        when(addon.getPlayerCommand()).thenReturn(Optional.empty());
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("runCommandCall", String.class, OneBlockPhase.class);
+        method.setAccessible(true);
+
+        // Should complete without NPE - it just closes inventory since playerCommand is empty
+        method.invoke(panel, "setcount", phase);
+    }
+
+    /**
+     * Test createPhaseButton with SELECT action (L361-367).
+     */
+    @Test
+    void testCreatePhaseButtonWithSelectAction() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(new OneBlockIslands(testIsland.getUniqueId()));
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        Map.Entry<Integer, OneBlockPhase> entry = Map.entry(0, phase);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(
+                    new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "SELECT", "cmd", "select_tooltip"),
+                    new ItemTemplateRecord.ActionRecords(ClickType.RIGHT, "VIEW", "cmd", "view_tooltip")
+                ),
+                Map.of(), null);
+
+        when(user.getTranslation(world, "title", "[phase]", "Plains")).thenReturn("Plains");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(user.getTranslation(world, "select_tooltip")).thenReturn("Select");
+        when(user.getTranslation(world, "view_tooltip")).thenReturn("View");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, entry);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test createNextButton with INDEXING and invoke click handler (L164-166, L186-197).
+     */
+    @Test
+    void testCreateNextButtonWithIndexingAndClickHandler() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        when(user.getTranslation(world, "title")).thenReturn("Next");
+        when(user.getTranslation(world, "desc", "number", "2")).thenReturn("Page 2");
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "NEXT", "content", "next_tooltip")),
+                Map.of("INDEXING", true), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.PanelItem panelItem = (world.bentobox.bentobox.api.panels.PanelItem) method.invoke(panel, template, slot);
+
+        assertNotNull(panelItem); // Verifies INDEXING branch was executed and PanelItem created
+    }
+
+    /**
+     * Test createPreviousButton with INDEXING and click handler (L243-246, L266-292).
+     */
+    @Test
+    void testCreatePreviousButtonWithIndexingAndClickHandler() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 2);
+
+        when(user.getTranslation(world, "title")).thenReturn("Previous");
+        when(user.getTranslation(world, "desc", "number", "2")).thenReturn("Page 2");
+
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "PREVIOUS", "content", "prev_tooltip")),
+                Map.of("INDEXING", true), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        world.bentobox.bentobox.api.panels.PanelItem panelItem = (world.bentobox.bentobox.api.panels.PanelItem) method.invoke(panel, template, slot);
+
+        assertNotNull(panelItem); // Verifies INDEXING branch was executed and PanelItem created
+    }
+
+    /**
+     * Test buildRequirementsText with empty requirements list.
+     */
+    @Test
+    void testBuildRequirementsTextEmpty() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("NoReqs");
+        phase.addBlock(Material.STONE, 100);
+        phase.setRequirements(List.of()); // Empty list
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildRequirementsText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, phase);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test buildDefaultDescription with biome present (L520-522).
+     */
+    @Test
+    void testBuildDefaultDescriptionWithBiome() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("BiomePhase");
+        phase.addBlock(Material.STONE, 100);
+        org.bukkit.block.Biome biome = mock(org.bukkit.block.Biome.class);
+        phase.setPhaseBiome(biome);
+
+        Class<?> reqTextClass = Class.forName("world.bentobox.aoneblock.panels.PhasesPanel$RequirementTexts");
+        java.lang.reflect.Constructor<?> reqConstructor = reqTextClass.getDeclaredConstructor(String.class, String.class, String.class, String.class);
+        reqConstructor.setAccessible(true);
+        Object reqTexts = reqConstructor.newInstance("", "", "", "");
+
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.starting-block", "number", "0")).thenReturn("Block 0");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.biome", "[biome]", "Plains")).thenReturn("Biome: Plains");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.description", "[starting-block]", "Block 0", "[biome]", "Biome: Plains", "[bank]", "", "[economy]", "", "[level]", "", "[permission]", "", "[blocks]", ""))
+            .thenReturn("Description with biome");
+
+        try (MockedStatic<LangUtilsHook> ms = mockStatic(LangUtilsHook.class)) {
+            ms.when(() -> LangUtilsHook.getBiomeName(biome, user)).thenReturn("Plains");
+
+            Method method = PhasesPanel.class.getDeclaredMethod("buildDefaultDescription", OneBlockPhase.class, reqTextClass, String.class);
+            method.setAccessible(true);
+
+            String result = (String) method.invoke(panel, phase, reqTexts, "");
+
+            assertNotNull(result);
+            assertTrue(result.contains("biome"));
+        }
+    }
+
+    /**
+     * Test buildDescriptionText with null template (default path) (L492).
+     */
+    @Test
+    void testBuildDescriptionTextNullTemplate() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        phase.setPhaseBiome(null);
+
+        ItemTemplateRecord template = new ItemTemplateRecord(null, null, null, List.of(), Map.of(), null); // description is null
+
+        Class<?> reqTextClass = Class.forName("world.bentobox.aoneblock.panels.PhasesPanel$RequirementTexts");
+        java.lang.reflect.Constructor<?> reqConstructor = reqTextClass.getDeclaredConstructor(String.class, String.class, String.class, String.class);
+        reqConstructor.setAccessible(true);
+        Object reqTexts = reqConstructor.newInstance("", "", "", "");
+
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.starting-block", "number", "0")).thenReturn("Block 0");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.description", "[starting-block]", "Block 0", "[biome]", "", "[bank]", "", "[economy]", "", "[level]", "", "[permission]", "", "[blocks]", ""))
+            .thenReturn("Default Description");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildDescriptionText", ItemTemplateRecord.class, OneBlockPhase.class, reqTextClass, String.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, template, phase, reqTexts, "");
+
+        assertNotNull(result);
+        assertTrue(result.contains("Default"));
+    }
+
+    /**
+     * Test createPhaseButton with VIEW-only action (no SELECT allowed).
+     */
+    @Test
+    void testCreatePhaseButtonViewOnlyCannotApply() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(5L); // Low lifetime so can't apply
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+        Map.Entry<Integer, OneBlockPhase> entry = Map.entry(0, phase);
+
+        // Only VIEW action, no SELECT (so canApply filtering removes SELECT actions)
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "VIEW", "cmd", "view")),
+                Map.of(), null);
+
+        when(user.getTranslation(world, "title", "[phase]", "Plains")).thenReturn("Plains");
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.blocks-prefix")).thenReturn("Blocks: ");
+        when(user.getTranslation("aoneblock.gui.buttons.phase.wrap-at")).thenReturn("50");
+        when(user.getTranslation(world, "view")).thenReturn("View");
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText(anyString())).thenAnswer(i -> {
+            String arg = i.getArgument(0);
+            return arg.substring(0, 1).toUpperCase() + arg.substring(1).toLowerCase();
+        });
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPhaseButton", ItemTemplateRecord.class, Map.Entry.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, entry);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test insertNewlines with color code at interval boundary (L593-615).
+     */
+    @Test
+    void testInsertNewlinesColorAtBoundary() throws Exception {
+        Method method = PhasesPanel.class.getDeclaredMethod("insertNewlines", String.class, int.class);
+        method.setAccessible(true);
+
+        // String with § at 10 chars
+        String input = "123456789§a more text";
+        String result = (String) method.invoke(null, input, 10);
+
+        assertTrue(result.contains("§")); // Color code preserved
+    }
+
+    /**
+     * Test getMaterialName with no LangUtils and valid material.
+     */
+    @Test
+    void testGetMaterialNameWithPrettify() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        when(hooksManager.getHook("LangUtils")).thenReturn(Optional.empty());
+        mockedUtil.when(() -> Util.prettifyText("IRON_ORE")).thenReturn("Iron Ore");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("getMaterialName", User.class, Material.class);
+        method.setAccessible(true);
+
+        String result = (String) method.invoke(panel, user, Material.IRON_ORE);
+
+        assertEquals("Iron Ore", result);
+    }
+
+    /**
+     * Test createNextButton with empty actions list (L200-212).
+     */
+    @Test
+    void testCreateNextButtonNoTooltips() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+
+        NavigableMap<Integer, OneBlockPhase> probs = new TreeMap<>();
+        for (int i = 0; i < 20; i++) {
+            OneBlockPhase p = createTestPhase("Phase" + i);
+            probs.put(i, p);
+        }
+        when(oneBlockManager.getBlockProbs()).thenReturn(probs);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 0);
+
+        when(user.getTranslation(world, "title")).thenReturn("Next");
+        when(user.getTranslation(world, "desc", "number", "2")).thenReturn("Page 2");
+
+        // Actions with null tooltips
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(new ItemTemplateRecord.ActionRecords(ClickType.LEFT, "NEXT", "content", null)),
+                Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 10));
+        when(slot.slot()).thenReturn(0);
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createNextButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result); // Should still create button, just without tooltips
+    }
+
+    /**
+     * Test createPreviousButton with null actions (L288-293).
+     */
+    @Test
+    void testCreatePreviousButtonNullActions() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        Field pageIndexField = PhasesPanel.class.getDeclaredField("pageIndex");
+        pageIndexField.setAccessible(true);
+        pageIndexField.set(panel, 1);
+
+        when(user.getTranslation(world, "title")).thenReturn("Previous");
+        when(user.getTranslation(world, "desc", "number", "1")).thenReturn("Page 1");
+
+        // Empty actions list
+        ItemTemplateRecord template = new ItemTemplateRecord(new ItemStack(Material.STONE),
+                "title", "desc",
+                List.of(), Map.of(), null);
+
+        TemplatedPanel.ItemSlot slot = mock(TemplatedPanel.ItemSlot.class);
+        when(slot.amountMap()).thenReturn(Map.of("PHASE", 1));
+
+        Method method = PhasesPanel.class.getDeclaredMethod("createPreviousButton", ItemTemplateRecord.class, TemplatedPanel.ItemSlot.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, template, slot);
+
+        assertNotNull(result);
+    }
+
+    /**
+     * Test buildRequirementsText with single ECO requirement only (L432).
+     */
+    @Test
+    void testBuildRequirementsTextEcoOnly() throws Exception {
+        setUpAddonMocks();
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(null);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = new OneBlockPhase("0");
+        phase.setPhaseName("EcoOnly");
+        phase.addBlock(Material.STONE, 100);
+        phase.setRequirements(List.of(new Requirement(ReqType.ECO, 500.0)));
+
+        when(user.getTranslationOrNothing("aoneblock.gui.buttons.phase.economy")).thenReturn("Economy: 500");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("buildRequirementsText", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        Object result = method.invoke(panel, phase);
+
+        assertNotNull(result);
+        Field economyField = result.getClass().getDeclaredField("economy");
+        economyField.setAccessible(true);
+        assertTrue(economyField.get(result).toString().contains("500"));
+    }
+}


### PR DESCRIPTION
# What's new

This is a bug-fix release.

* **Miner minions can mine the magic block again.** Breaking the magic block with a JetsMinions Miner minion threw a `NullPointerException` and left the block gone until it was manually restored with `/ob respawnblock`. The minion break path no longer runs the player-only magic-block protection check that caused the crash, so the block cycles and respawns as expected. This regression had been present since 1.22.0. Fixes [#525](https://github.com/BentoBoxWorld/AOneBlock/issues/525).
* **`my_island_*` placeholders fixed for visiting team members.** When a player who belongs to a team visited another island, the `my_island_*` placeholders resolved to the visited island's team data instead of the player's own island. They now always resolve to the player's own island.

## Compatibility

✔️ BentoBox API 3.15.0+
✔️ Minecraft 1.21.5 or later
✔️ Java 21

## Upgrading

1. Stop the server. Make a backup just in case.
2. Copy this jar over the old one.
3. Restart the server.
4. You should be good to go!

## What's Changed
* Fix `my_island_*` placeholders resolving to team island when player is visiting as a member by @Copilot in https://github.com/BentoBoxWorld/AOneBlock/pull/519
* Add MC 26.1.2 to Modrinth game-versions by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/521
* Add CurseForge publish workflow by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/522
* Pin publish workflow to SHA and enable Hangar by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/523
* Bump pinned reusable workflow to fe4b1f0 by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/524
* Fix NPE when a minion breaks the magic block by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/526
* Resolve SonarCloud issues and Javadoc cleanup by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/527
* Bump JaCoCo to 0.8.15 for Java 25 support by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/528
* Bump version to 1.25.1 by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/529
* Add PhasesPanel test suite (5% → 85% coverage) by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/530

**Full Changelog**: https://github.com/BentoBoxWorld/AOneBlock/compare/1.25.0...1.25.1
