### PR TITLE
fix: cancel denied magic-block break early to stop Jobs reward exploit (#534)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.25.1</build.version>
+        <build.version>1.25.2</build.version>
         <!-- SonarCloud -->
         <sonar.projectKey>BentoBoxWorld_AOneBlock</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BlockListener.java
@@ -220,6 +220,37 @@ public class BlockListener extends FlagListener implements Listener {
     }
 
     /**
+     * Cancels a magic-block break as early as possible when the player lacks the
+     * {@link AOneBlock#MAGIC_BLOCK} permission.
+     * <p>
+     * The full magic-block processing runs at {@link EventPriority#HIGHEST} so that
+     * other protection plugins get a chance to cancel first. However, reward-granting
+     * plugins such as Jobs Reborn also listen at {@code HIGHEST} with
+     * {@code ignoreCancelled = true}. Within a single priority the execution order is
+     * just plugin-registration order, so Jobs could pay out <em>before</em> our
+     * {@code HIGHEST} handler cancels the break. Because the magic block respawns when
+     * the break is cancelled, that let players mine it endlessly for infinite rewards.
+     * <p>
+     * Cancelling the denied break here, at {@link EventPriority#LOWEST}, guarantees it
+     * happens before any {@code ignoreCancelled = true} handler at a later priority, so
+     * those plugins are skipped and no reward is granted.
+     *
+     * @param e The BlockBreakEvent.
+     * @see <a href="https://github.com/BentoBoxWorld/AOneBlock/issues/534">Issue #534</a>
+     */
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockBreakDeny(final BlockBreakEvent e) {
+        if (!addon.inWorld(e.getBlock().getWorld())) {
+            return;
+        }
+        Location l = e.getBlock().getLocation();
+        // checkIsland cancels the event and sends the protection message if the player
+        // is not allowed to break the magic block.
+        addon.getIslands().getIslandAt(l).filter(i -> l.equals(i.getCenter()))
+                .ifPresent(i -> checkIsland(e, e.getPlayer(), i.getCenter(), addon.MAGIC_BLOCK));
+    }
+
+    /**
      * Handles the breaking of the magic block by a player.
      * @param e The BlockBreakEvent.
      */

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
@@ -13,8 +13,11 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1082,9 +1085,9 @@ class BlockListenerTest2 extends CommonTestSetup {
      */
     @Test
     void testOnBlockBreakDenyCancelsWhenNotAllowed() {
-        BlockListener spyBl = Mockito.spy(bl);
+        BlockListener spyBl = spy(bl);
         // Emulate FlagListener.checkIsland's deny behaviour: cancel the event and return false.
-        Mockito.doAnswer(inv -> {
+        doAnswer(inv -> {
             ((BlockBreakEvent) inv.getArgument(0)).setCancelled(true);
             return false;
         }).when(spyBl).checkIsland(any(), any(), any(), any());
@@ -1105,8 +1108,8 @@ class BlockListenerTest2 extends CommonTestSetup {
      */
     @Test
     void testOnBlockBreakDenyAllowsWhenPermitted() {
-        BlockListener spyBl = Mockito.spy(bl);
-        Mockito.doReturn(true).when(spyBl).checkIsland(any(), any(), any(), any());
+        BlockListener spyBl = spy(bl);
+        doReturn(true).when(spyBl).checkIsland(any(), any(), any(), any());
 
         BlockBreakEvent e = new BlockBreakEvent(magicBlock, mockPlayer);
         spyBl.onBlockBreakDeny(e);
@@ -1122,7 +1125,7 @@ class BlockListenerTest2 extends CommonTestSetup {
     @Test
     void testOnBlockBreakDenyNotInWorld() {
         when(addon.inWorld(world)).thenReturn(false);
-        BlockListener spyBl = Mockito.spy(bl);
+        BlockListener spyBl = spy(bl);
 
         BlockBreakEvent e = new BlockBreakEvent(magicBlock, mockPlayer);
         spyBl.onBlockBreakDeny(e);
@@ -1144,7 +1147,7 @@ class BlockListenerTest2 extends CommonTestSetup {
         Location otherLoc = mock(Location.class);
         when(other.getLocation()).thenReturn(otherLoc);
         when(im.getIslandAt(otherLoc)).thenReturn(Optional.of(island));
-        BlockListener spyBl = Mockito.spy(bl);
+        BlockListener spyBl = spy(bl);
 
         BlockBreakEvent e = new BlockBreakEvent(other, mockPlayer);
         spyBl.onBlockBreakDeny(e);

--- a/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BlockListenerTest2.java
@@ -42,6 +42,8 @@ import org.bukkit.block.data.type.Leaves;
 import org.bukkit.block.data.Brushable;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
@@ -1048,6 +1050,107 @@ class BlockListenerTest2 extends CommonTestSetup {
         bl.onBlockBreakByMinion(e);
 
         verify(im, never()).getIslandAt(any());
+    }
+
+    // =========================================================================
+    // onBlockBreakDeny — early cancel to stop reward exploits (issue #534)
+    // =========================================================================
+
+    /**
+     * The early-deny handler must run at {@link EventPriority#LOWEST} with
+     * {@code ignoreCancelled = true}. Reward-granting plugins such as Jobs Reborn
+     * listen for the {@link BlockBreakEvent} at {@code HIGHEST} with
+     * {@code ignoreCancelled = true}; cancelling here, before them, guarantees they
+     * are skipped when the player lacks the magic-block permission.
+     * See https://github.com/BentoBoxWorld/AOneBlock/issues/534
+     */
+    @Test
+    void testOnBlockBreakDenyRegisteredAtLowestPriority() throws NoSuchMethodException {
+        EventHandler eh = BlockListener.class.getMethod("onBlockBreakDeny", BlockBreakEvent.class)
+                .getAnnotation(EventHandler.class);
+        assertNotNull(eh);
+        assertEquals(EventPriority.LOWEST, eh.priority());
+        assertTrue(eh.ignoreCancelled());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakDeny(BlockBreakEvent)}
+     * When the player lacks the MAGIC_BLOCK permission the break is cancelled at this
+     * early stage (via checkIsland), so later reward plugins are skipped. Regression
+     * test for https://github.com/BentoBoxWorld/AOneBlock/issues/534
+     */
+    @Test
+    void testOnBlockBreakDenyCancelsWhenNotAllowed() {
+        BlockListener spyBl = Mockito.spy(bl);
+        // Emulate FlagListener.checkIsland's deny behaviour: cancel the event and return false.
+        Mockito.doAnswer(inv -> {
+            ((BlockBreakEvent) inv.getArgument(0)).setCancelled(true);
+            return false;
+        }).when(spyBl).checkIsland(any(), any(), any(), any());
+
+        BlockBreakEvent e = new BlockBreakEvent(magicBlock, mockPlayer);
+        spyBl.onBlockBreakDeny(e);
+
+        assertTrue(e.isCancelled());
+        // The flag was checked against the island centre for the breaking player.
+        verify(spyBl).checkIsland(any(), eq(mockPlayer), eq(location), any());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakDeny(BlockBreakEvent)}
+     * When the player is allowed, the early handler leaves the event untouched so that
+     * normal magic-block processing and legitimate rewards proceed.
+     */
+    @Test
+    void testOnBlockBreakDenyAllowsWhenPermitted() {
+        BlockListener spyBl = Mockito.spy(bl);
+        Mockito.doReturn(true).when(spyBl).checkIsland(any(), any(), any(), any());
+
+        BlockBreakEvent e = new BlockBreakEvent(magicBlock, mockPlayer);
+        spyBl.onBlockBreakDeny(e);
+
+        assertFalse(e.isCancelled());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakDeny(BlockBreakEvent)}
+     * Not in an addon world → early return, the flag is never checked.
+     */
+    @Test
+    void testOnBlockBreakDenyNotInWorld() {
+        when(addon.inWorld(world)).thenReturn(false);
+        BlockListener spyBl = Mockito.spy(bl);
+
+        BlockBreakEvent e = new BlockBreakEvent(magicBlock, mockPlayer);
+        spyBl.onBlockBreakDeny(e);
+
+        assertFalse(e.isCancelled());
+        verify(spyBl, never()).checkIsland(any(), any(), any(), any());
+    }
+
+    /**
+     * Test method for
+     * {@link world.bentobox.aoneblock.listeners.BlockListener#onBlockBreakDeny(BlockBreakEvent)}
+     * Block is in world but is not the island centre (magic block) → the flag is never
+     * checked, so ordinary block breaking elsewhere on the island is unaffected.
+     */
+    @Test
+    void testOnBlockBreakDenyNotCenterBlock() {
+        Block other = mock(Block.class);
+        when(other.getWorld()).thenReturn(world);
+        Location otherLoc = mock(Location.class);
+        when(other.getLocation()).thenReturn(otherLoc);
+        when(im.getIslandAt(otherLoc)).thenReturn(Optional.of(island));
+        BlockListener spyBl = Mockito.spy(bl);
+
+        BlockBreakEvent e = new BlockBreakEvent(other, mockPlayer);
+        spyBl.onBlockBreakDeny(e);
+
+        assertFalse(e.isCancelled());
+        verify(spyBl, never()).checkIsland(any(), any(), any(), any());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Problem

Fixes #534 — Jobs Reborn awards infinite rewards when a player mines the magic block on an island where the `MAGIC_BLOCK` flag denies them, despite general block-breaking being allowed.

## Root cause

An event-priority race:

- **Jobs Reborn** (`JobsPaymentListener`) pays out from its `BlockBreakEvent` handler at `@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)`.
- **AOneBlock** (`BlockListener.onBlockBreak`) also ran at `HIGHEST, ignoreCancelled = true`, and only there did it call `checkIsland(...MAGIC_BLOCK)`, whose deny path cancels the break.

`ignoreCancelled = true` means "skip me if the event is *already* cancelled." Within a single priority slot, Bukkit fires handlers in **plugin-registration order**, which is nondeterministic across setups. When Jobs' `HIGHEST` handler ran *before* AOneBlock's, the event wasn't cancelled yet, so Jobs paid the reward. AOneBlock then cancelled the break — and since the magic block respawns on a cancelled break, a player lacking the `MAGIC_BLOCK` flag could mine it endlessly for infinite Jobs money.

## Fix

Add a dedicated early-deny handler that performs the `MAGIC_BLOCK` flag check at `EventPriority.LOWEST`:

```java
@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
public void onBlockBreakDeny(final BlockBreakEvent e) {
    if (!addon.inWorld(e.getBlock().getWorld())) return;
    Location l = e.getBlock().getLocation();
    addon.getIslands().getIslandAt(l).filter(i -> l.equals(i.getCenter()))
            .ifPresent(i -> checkIsland(e, e.getPlayer(), i.getCenter(), addon.MAGIC_BLOCK));
}
```

Cancelling at `LOWEST` is strictly before any later `ignoreCancelled = true` handler, so Jobs' `HIGHEST` handler is guaranteed to be skipped for a denied break — no reward is granted. Full magic-block processing stays at `HIGHEST` (other protection plugins still get their say for legitimate breaks), and allowed breaks are unaffected.

### Caveat

This closes the exploit for plugins that respect cancellation (Jobs does, via `ignoreCancelled = true`). A plugin that pays out at `LOWEST` or ignores cancellation entirely couldn't be stopped this way, but Jobs specifically is now handled.

## Tests

Added 5 regression tests to `BlockListenerTest2`:
- asserts the handler is registered at `LOWEST` / `ignoreCancelled = true` (the crux of the fix)
- denied break is cancelled early
- allowed break is left untouched
- not-in-world and non-center-block guard clauses skip the flag check

Full `BlockListener*` / `BlockProtect` suites: **65 tests, 0 failures**.

## Version

Bumped to **1.25.2** (bug-fix release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)