### PR TITLE
Release 1.26.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Do not change unless you want different name for local builds. -->
         <build.number>-LOCAL</build.number>
         <!-- This allows to change between versions. -->
-        <build.version>1.26.2</build.version>
+        <build.version>1.26.3</build.version>
         <!-- SonarCloud -->
         <sonar.projectKey>BentoBoxWorld_AOneBlock</sonar.projectKey>
         <sonar.organization>bentobox-world</sonar.organization>

--- a/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
+++ b/src/main/java/world/bentobox/aoneblock/panels/PhasesPanel.java
@@ -539,11 +539,28 @@ public class PhasesPanel
         {
             return false;
         }
+        if (!this.hasSetCountPermission())
+        {
+            return false;
+        }
         if (phase.getBlockNumberValue() >= this.oneBlockIsland.getLifetime())
         {
             return false;
         }
         return !this.phaseRequirementsFail(phase, this.oneBlockIsland);
+    }
+
+    /**
+     * Checks that the player holds the permission of the setcount command that a phase
+     * click runs, so the "click to change" action is only offered when it can succeed.
+     */
+    private boolean hasSetCountPermission()
+    {
+        String label = this.addon.getSettings().getSetCountCommand().split(" ")[0];
+        return this.addon.getPlayerCommand()
+                .flatMap(mainCommand -> mainCommand.getSubCommand(label))
+                .map(subCommand -> this.user.hasPermission(subCommand.getPermission()))
+                .orElse(true);
     }
 
     /**

--- a/src/test/java/world/bentobox/aoneblock/panels/PhasesPanelTest.java
+++ b/src/test/java/world/bentobox/aoneblock/panels/PhasesPanelTest.java
@@ -42,6 +42,7 @@ import world.bentobox.aoneblock.oneblocks.Requirement.ReqType;
 import world.bentobox.bank.Bank;
 import world.bentobox.bank.BankManager;
 import world.bentobox.bank.data.Money;
+import world.bentobox.bentobox.api.commands.CompositeCommand;
 import world.bentobox.bentobox.api.panels.TemplatedPanel;
 import world.bentobox.bentobox.api.panels.reader.ItemTemplateRecord;
 import world.bentobox.bentobox.api.user.User;
@@ -539,6 +540,84 @@ class PhasesPanelTest extends CommonTestSetup {
         when(im.getIsland(world, user)).thenReturn(testIsland);
         when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
         when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertTrue(result);
+    }
+
+    /**
+     * Test canApplyPhase returns false when the player lacks the setcount command
+     * permission — the "click to change" action must not be offered.
+     */
+    @Test
+    void testCanApplyPhaseNoSetCountPermission() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(100L);
+        oneBlockIsland.setLastPhaseChangeTime(System.currentTimeMillis());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        // The setcount command exists and carries a permission the player does not have
+        CompositeCommand mainCommand = mock(CompositeCommand.class);
+        CompositeCommand setCountCommand = mock(CompositeCommand.class);
+        when(mainCommand.getSubCommand("setcount")).thenReturn(Optional.of(setCountCommand));
+        when(setCountCommand.getPermission()).thenReturn("aoneblock.island.setcount");
+        when(addon.getPlayerCommand()).thenReturn(Optional.of(mainCommand));
+        when(mockPlayer.hasPermission("aoneblock.island.setcount")).thenReturn(false);
+
+        Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
+        constructor.setAccessible(true);
+        panel = constructor.newInstance(addon, world, user);
+
+        OneBlockPhase phase = createTestPhase("Plains");
+
+        Method method = PhasesPanel.class.getDeclaredMethod("canApplyPhase", OneBlockPhase.class);
+        method.setAccessible(true);
+
+        boolean result = (boolean) method.invoke(panel, phase);
+
+        assertFalse(result);
+    }
+
+    /**
+     * Test canApplyPhase returns true when the player holds the setcount permission.
+     */
+    @Test
+    void testCanApplyPhaseWithSetCountPermission() throws Exception {
+        setUpAddonMocks();
+        Island testIsland = new Island();
+        testIsland.setOwner(uuid);
+        OneBlockIslands oneBlockIsland = new OneBlockIslands(testIsland.getUniqueId());
+        oneBlockIsland.setLifetime(100L);
+        oneBlockIsland.setLastPhaseChangeTime(System.currentTimeMillis());
+
+        User user = User.getInstance(mockPlayer);
+        when(im.getIsland(world, user)).thenReturn(testIsland);
+        when(blockListener.getIsland(testIsland)).thenReturn(oneBlockIsland);
+        when(oneBlockManager.getBlockProbs()).thenReturn(createBlockProbs());
+
+        CompositeCommand mainCommand = mock(CompositeCommand.class);
+        CompositeCommand setCountCommand = mock(CompositeCommand.class);
+        when(mainCommand.getSubCommand("setcount")).thenReturn(Optional.of(setCountCommand));
+        when(setCountCommand.getPermission()).thenReturn("aoneblock.island.setcount");
+        when(addon.getPlayerCommand()).thenReturn(Optional.of(mainCommand));
+        when(mockPlayer.hasPermission("aoneblock.island.setcount")).thenReturn(true);
 
         Constructor<PhasesPanel> constructor = PhasesPanel.class.getDeclaredConstructor(AOneBlock.class, World.class, User.class);
         constructor.setAccessible(true);


### PR DESCRIPTION
Bug-fix release.

**Fix:** `/ob phases` offered the "Click to change" tooltip regardless of whether the player held the permission of the `setcount` command the click runs, so players with `aoneblock.island.setcount` negated got a permission error on click. The panel now checks that permission before offering the action, and stays permissive if the subcommand cannot be resolved.

## What's Changed
* Only offer 'Click to change' in the phases GUI to players who can use it by @tastybento in https://github.com/BentoBoxWorld/AOneBlock/pull/545

**Full Changelog**: https://github.com/BentoBoxWorld/AOneBlock/compare/1.26.2...1.26.3