### PR TITLE
ci: bump publish-platforms pin to the multipart-JSON fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   publish:
-    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@ca2dcd167e8db4e0f671a976080744dda43801a6 # master
+    uses: bentoboxworld/.github/.github/workflows/publish-platforms.yml@1f91a0edf72e8c86d671b3b8fdd3121ac6fb88e1 # master
     with:
       use_release_asset: "true"          # publish the jar attached to the release; do not rebuild
       hangar_slug: "AOneBlock"           # blank = skip Hangar


### PR DESCRIPTION
## What

Bumps the pinned SHA of the shared `publish-platforms.yml` reusable workflow from `ca2dcd16` (2026-07-03) to `1f91a0e` (master HEAD, 2026-07-20).

## Why

The 1.26.3 publish failed on **both** CurseForge and Hangar ([run](https://github.com/BentoBoxWorld/AOneBlock/actions/runs/30468254213)):

- CurseForge — `{"errorCode":1002,"errorMessage":"Error in field \`metadata\`:\nInvalid JSON."}`
- Hangar — `{"status":400,"detail":"Failed to read request"}`

Both are the same root cause. The pinned version passes the multipart JSON as an inline curl value:

```
-F "metadata=${META};type=application/json"
```

curl reads `;` in an inline `-F` value as the start of a `type=`/`filename=` attribute, so the JSON is truncated at the first semicolon in the changelog. The 1.26.3 release notes contain one (`...(ChunkBlock #11); that panel was derived...`); earlier releases only succeeded because their notes happened to contain none.

BentoBoxWorld/.github#13 fixed this on 2026-07-20 by writing the JSON to a file and using curl's `<file` form (`-F "metadata=<cf_meta.json;type=application/json"`), but this repo was still pinned to the commit before it.

## Follow-up

Every other BentoBoxWorld repo except AcidIsland is still pinned to the stale `ca2dcd16` and will hit this the moment a release body contains a semicolon.

Modrinth was unaffected — it does not go through this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAQ3YQkcfRoCZEwa6SPJcp