### PR TITLE
Convert all locale files to MiniMessage

### DIFF
--- a/src/main/resources/locales/cs.yml
+++ b/src/main/resources/locales/cs.yml
@@ -3,111 +3,109 @@ protection:
     MAGIC_BLOCK:
       name: Ochrana Kouzelného Bloku
       description: |-
-        &b Hodnost, která může rozbít
-        &b kouzelný blok, pokud
-        &b dokáže rozbíjet bloky.
-      hint: "&c Vaše hodnost nemůže rozbít kouzelný blok!"
+        <aqua>Hodnost, která může rozbít
+        kouzelný blok, pokud
+        dokáže rozbíjet bloky.</aqua>
+      hint: "<red>Vaše hodnost nemůže rozbít kouzelný blok!</red>"
     START_SAFETY:
       name: Počáteční Bezpečnost
       description: |-
-        &b Zabrání novým hráčům
-        &b v pohybu po dobu 1 minuty,
-        &b aby nespadli.
-      hint: "&c Pohyb zablokován kvůli bezpečnosti na [number] sekund!"
-      free-to-move: "&a Můžete se volně pohybovat. Buďte opatrní!"
+        <aqua>Zabrání novým hráčům
+        v pohybu po dobu 1 minuty,
+        aby nespadli.</aqua>
+      hint: "<red>Pohyb zablokován kvůli bezpečnosti na [number] sekund!</red>"
+      free-to-move: "<green>Můžete se volně pohybovat. Buďte opatrní!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Zobrazuje stavový panel
-          &b pro každou fázi.
+      name: Boss Bar
+      description: |-
+        <aqua>Zobrazuje stavový panel
+        pro každou fázi.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Zobrazuje stav
-        &b pro každou fázi
-        &b v Action Baru.
+        <aqua>Zobrazuje stav
+        pro každou fázi
+        v Action Baru.</aqua>
 aoneblock:
   bossbar:
     title: Bloky zbývající
-    status: '&a Fázové bloky & B [done] & d / & b [total]'
+    status: '<green>Fázové bloky & B [done] & d / & b [total]</green>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar není pro tento ostrov aktivní'
+    not-active: '<red>Boss Bar není pro tento ostrov aktivní</red>'
   actionbar:
-    status: "&a Fáze: &b [phase-name] &d | &a Bloky: &b [done] &d / &b [total] &d | &a Postup: &b [percent-done]"
-    not-active: "&c Action Bar není pro tento ostrov aktivní"
+    status: "<green>Fáze: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Bloky: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Postup: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Action Bar není pro tento ostrov aktivní</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count> [lifetime]
         description: nastavit počet bloků hráče
-        set: '&a počet [name] je nastaven na [number]'
-        set-lifetime: '&a [name] je nastaveno na [number]'
+        set: '<green>počet [name] je nastaven na [number]</green>'
+        set-lifetime: '<green>[name] je nastaveno na [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: dejte pohled na hrudník do fáze se specifikovanou vzácností
-        chest-is-empty: '&c Ten hrudník je prázdný, takže jej nelze přidat'
-        unknown-phase: '&c Neznámá fáze. Chcete-li si je prohlédnout, použijte tabulátor'
-        unknown-rarity: '&c Neznámá vzácnost. Používejte COMMON, UNCOMMON, RARE nebo EPIC'
-        look-at-chest: '&c Podívejte se na naplněnou hruď a nastavte ji'
-        only-single-chest: '&c Lze nastavit pouze jednotlivé bedny'
-        success: '&a Hrudník byl úspěšně přidán do fáze'
-        failure: '&c Hrudník nelze přidat do fáze! Chyby najdete na konzole'
+        chest-is-empty: '<red>Ten hrudník je prázdný, takže jej nelze přidat</red>'
+        unknown-phase: '<red>Neznámá fáze. Chcete-li si je prohlédnout, použijte tabulátor</red>'
+        unknown-rarity: '<red>Neznámá vzácnost. Používejte COMMON, UNCOMMON, RARE nebo EPIC</red>'
+        look-at-chest: '<red>Podívejte se na naplněnou hruď a nastavte ji</red>'
+        only-single-chest: '<red>Lze nastavit pouze jednotlivé bedny</red>'
+        success: '<green>Hrudník byl úspěšně přidán do fáze</green>'
+        failure: '<red>Hrudník nelze přidat do fáze! Chyby najdete na konzole</red>'
       sanity:
         parameters: <fáze>
         description: zobrazí v konzoli kontrolu pravděpodobnosti fází
-        see-console: '&a Podívejte se do konzoly pro zprávu'
+        see-console: '<green>Podívejte se do konzoly pro zprávu</green>'
     count:
       description: zobrazit počet bloků a fázi
-      info: '&a Jste na bloku &b [number] ve fázi &a [name]'
+      info: '<green>Jste na bloku </green><aqua>[number] ve fázi </aqua><green>[name]</green>'
     info:
-      count: >-
-        Ostrov &a je na bloku &b [number]&a ve fázi &b [name] &a. Počet doživotí
-        &b [lifetime] &a.
+      count: 'Ostrov <green>je na bloku </green><aqua>[number]</aqua><green> ve fázi </green><aqua>[name] </aqua><green>. Počet doživotí </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: zobrazit seznam všech fází
-      title: '&2 Fáze OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] bloků'
+      title: '<dark_green>Fáze OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] bloků</aqua>'
     island:
       bossbar:
         description: přepíná fázový šéfový bar
-        status_on: '&b Bossbar se otočil &a zapnul'
-        status_off: '&b Bossbar se &c otočil'
+        status_on: '<aqua>Bossbar se otočil </aqua><green>zapnul</green>'
+        status_off: '<aqua>Bossbar se </aqua><red>otočil</red>'
       actionbar:
         description: přepíná action bar fáze
-        status_on: "&b Action Bar &a zapnut"
-        status_off: "&b Action Bar &c vypnut"
+        status_on: "<aqua>Action Bar </aqua><green>zapnut</green>"
+        status_off: "<aqua>Action Bar </aqua><red>vypnut</red>"
       setcount:
         parameters: <count>
         description: nastavte počet bloků na dříve dokončenou hodnotu
-        set: '&a Počet nastaven na [number].'
-        too-high: '&c Maximálně můžeš nastavit [number]!'
+        set: '<green>Počet nastaven na [number].</green>'
+        too-high: '<red>Maximálně můžeš nastavit [number]!</red>'
     respawn-block:
       description: respawnuje magický blok v situacích, kdy zmizí
-      block-exist: '&a Blok existuje, nevyžadoval respawning. Označil jsem to za vás.'
-      block-respawned: '&a Blok byl znovu vytvořen.'
+      block-exist: '<green>Blok existuje, nevyžadoval respawning. Označil jsem to za vás.</green>'
+      block-respawned: '<green>Blok byl znovu vytvořen.</green>'
   phase:
     insufficient-level: Tvůj ostrov je na příliš nízké úrovni, musí být alespoň [number].
     insufficient-funds: Nemáš dostatečné prostředky! Musíš mít alespoň [number].
     insufficient-bank-balance: V Bance ostrova není dostatek financí! Je potřeba alespoň [number].
-    insufficient-permission: '&c Nemůžete pokračovat, dokud nezískáte oprávnění [name]!'
-    cooldown: '&c Další fáze bude dostupná za [number] sekund!'
+    insufficient-permission: '<red>Nemůžete pokračovat, dokud nezískáte oprávnění [name]!</red>'
+    cooldown: '<red>Další fáze bude dostupná za [number] sekund!</red>'
   placeholders:
     infinite: Nekonečný
     my-island-phase-default: Neznámá
   gui:
     titles:
-      phases: '&0&l Jednoblokové fáze'
+      phases: '<black><bold>Jednoblokové fáze</bold></black>'
     buttons:
       previous:
-        name: '&f&l Předchozí stránka'
-        description: '&7 Přepnout na stránku [number]'
+        name: '<white><bold>Předchozí stránka</bold></white>'
+        description: '<gray>Přepnout na stránku [number]</gray>'
       next:
-        name: '&f&l Další stránka'
-        description: '&7 Přepnout na stránku [number]'
+        name: '<white><bold>Další stránka</bold></white>'
+        description: '<gray>Přepnout na stránku [number]</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -115,20 +113,20 @@ aoneblock:
           [economy] 
           [level]
           [permission]
-        starting-block: '&7 Spustí se po rozbití bloků &e [number].'
-        biome: '&7 Biom: &e [biome]'
-        bank: '&7 Vyžaduje &e $[number] &7 na bankovním účtu.'
-        economy: '&7 Vyžaduje &e $[number] &7 v hráčském účtu.'
-        level: '&7 Vyžaduje &e [number] &7 úroveň ostrova.'
-        permission: '&7 Vyžaduje oprávnění `&e[permission]&7`.'
-        blocks-prefix: '&7 Bloků ve fázi -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Spustí se po rozbití bloků </gray><yellow>[number].</yellow>'
+        biome: '<gray>Biom: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Vyžaduje </gray><yellow>$[number] </yellow><gray>na bankovním účtu.</gray>'
+        economy: '<gray>Vyžaduje </gray><yellow>$[number] </yellow><gray>v hráčském účtu.</gray>'
+        level: '<gray>Vyžaduje </gray><yellow>[number] </yellow><gray>úroveň ostrova.</gray>'
+        permission: '<gray>Vyžaduje oprávnění `</gray><yellow>[permission]</yellow><gray>`.</gray>'
+        blocks-prefix: '<gray>Bloků ve fázi -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Klepnutím na &7 zobrazíte předchozí stránku.'
-      click-to-next: '&e Klepnutím na &7 zobrazíte další stránku.'
-      click-to-change: '&e Klikněte na &7 pro změnu.'
+      click-to-previous: '<yellow>Klepnutím na </yellow><gray>zobrazíte předchozí stránku.</gray>'
+      click-to-next: '<yellow>Klepnutím na </yellow><gray>zobrazíte další stránku.</gray>'
+      click-to-change: '<yellow>Klikněte na </yellow><gray>pro změnu.</gray>'
   island:
     starting-hologram: |-
-      &a Vítejte v AOneBlock
-      &e Prolomte tento blok
+      <green>Vítejte v AOneBlock
+      </green><yellow>Prolomte tento blok</yellow>

--- a/src/main/resources/locales/de.yml
+++ b/src/main/resources/locales/de.yml
@@ -3,127 +3,115 @@ protection:
     MAGIC_BLOCK:
       name: Schutz des Magischen Blocks
       description: |-
-        &b Rang, der den magischen
-        &b Block zerstören kann, falls
-        &b Blöcke zerstört werden können.
-      hint: "&c Dein Rang kann den magischen Block nicht zerstören!"
+        <aqua>Rang, der den magischen
+        Block zerstören kann, falls
+        Blöcke zerstört werden können.</aqua>
+      hint: "<red>Dein Rang kann den magischen Block nicht zerstören!</red>"
     START_SAFETY:
       name: Start-Sicherheit
       description: |-
-        &b Verhindert, dass neue Spieler
-        &b sich 1 Minute lang bewegen,
-        &b damit sie nicht herunterfallen.
-      hint: "&c Bewegung aus Sicherheitsgründen für [number] weitere Sekunden blockiert!"
-      free-to-move: "&a Du kannst dich frei bewegen. Sei vorsichtig!"
+        <aqua>Verhindert, dass neue Spieler
+        sich 1 Minute lang bewegen,
+        damit sie nicht herunterfallen.</aqua>
+      hint: "<red>Bewegung aus Sicherheitsgründen für [number] weitere Sekunden blockiert!</red>"
+      free-to-move: "<green>Du kannst dich frei bewegen. Sei vorsichtig!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss-Balken
-        description: |-
-          &b Zeigt eine Statusleiste
-          &b für jede Phase.
+      name: Boss-Balken
+      description: |-
+        <aqua>Zeigt eine Statusleiste
+        für jede Phase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action-Leiste
       description: |-
-        &b Zeigt einen Status
-        &b für jede Phase
-        &b in der Action-Leiste.
+        <aqua>Zeigt einen Status
+        für jede Phase
+        in der Action-Leiste.</aqua>
 aoneblock:
   bossbar:
     title: Verbleibende Blöcke
-    status: '&a Phasenblöcke &b [done] &d / &b [total]'
+    status: '<green>Phasenblöcke </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar ist für diese Insel nicht aktiv'
+    not-active: '<red>Boss Bar ist für diese Insel nicht aktiv</red>'
   actionbar:
-    status: "&a Phase: &b [phase-name] &d | &a Blöcke: &b [done] &d / &b [total] &d | &a Fortschritt: &b [percent-done]"
-    not-active: "&c Action Bar ist für diese Insel nicht aktiv"
+    status: "<green>Phase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blöcke: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Fortschritt: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Action Bar ist für diese Insel nicht aktiv</red>"
   commands:
     admin:
       setcount:
         parameters: <Name> <Anzahl>[lifetime]
         description: Setze die Blockanzahl des Spielers
-        set: '&a [name] zählt auf [number]'
-        set-lifetime: Die Lebenszeitanzahl von &a [name] wurde auf [number] gesetzt
+        set: '<green>[name] zählt auf [number]</green>'
+        set-lifetime: 'Die Lebenszeitanzahl von <green>[name] wurde auf [number] gesetzt</green>'
       setchest:
         parameters: <Phase> <Rarität>
         description: >-
           Versetzen Sie die betrachtete Truhe in eine Phase mit der angegebenen
           Seltenheit
-        chest-is-empty: '&c Diese Truhe ist leer und kann daher nicht hinzugefügt werden'
-        unknown-phase: '&c Unbekannte Phase. Verwenden Sie tab-complete, um sie anzuzeigen'
-        unknown-rarity: >-
-          &c Unbekannte Seltenheit. Verwenden Sie COMMON, UNCOMMON, RARE oder
-          EPIC
-        look-at-chest: '&c Sieh dir eine gefüllte Truhe an, um sie einzustellen'
-        only-single-chest: '&c Es können nur einzelne Truhen eingestellt werden'
-        success: '&a Eine Truhe erfolgreich zur Phase hinzugefügt'
-        failure: >-
-          &c Truhe konnte nicht zur Phase hinzugefügt werden! Siehe Konsole für
-          Fehler
+        chest-is-empty: '<red>Diese Truhe ist leer und kann daher nicht hinzugefügt werden</red>'
+        unknown-phase: '<red>Unbekannte Phase. Verwenden Sie tab-complete, um sie anzuzeigen</red>'
+        unknown-rarity: '<red>Unbekannte Seltenheit. Verwenden Sie COMMON, UNCOMMON, RARE oder EPIC</red>'
+        look-at-chest: '<red>Sieh dir eine gefüllte Truhe an, um sie einzustellen</red>'
+        only-single-chest: '<red>Es können nur einzelne Truhen eingestellt werden</red>'
+        success: '<green>Eine Truhe erfolgreich zur Phase hinzugefügt</green>'
+        failure: '<red>Truhe konnte nicht zur Phase hinzugefügt werden! Siehe Konsole für Fehler</red>'
       sanity:
         parameters: <Phase>
         description: >-
           Zeigen Sie eine Überprüfung der Phasenwahrscheinlichkeiten in der
           Konsole an
-        see-console: '&a Den Bericht finden Sie in der Konsole'
+        see-console: '<green>Den Bericht finden Sie in der Konsole</green>'
     count:
       description: Zeige die Blockanzahl und Phase
-      info: '&a Sie befinden sich in der Phase &a [name] in Block &b [number]'
+      info: '<green>Sie befinden sich in der Phase [name] in Block </green><aqua>[number]</aqua>'
     info:
-      count: >-
-        &a Island befindet sich in Block &b [number]&a in der Phase &b [Name]
-        &a. Lebenszeitanzahl &b [lifetime] &a.
+      count: '<green>Island befindet sich in Block </green><aqua>[number]</aqua><green> in der Phase </green><aqua>[Name] </aqua><green>. Lebenszeitanzahl </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: Zeigen Sie eine Liste aller Phasen an
-      title: '&2 OneBlock-Phasen'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] Blöcke'
+      title: '<dark_green>OneBlock-Phasen</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] Blöcke</aqua>'
     island:
       bossbar:
         description: Phase Boss Bar umschalten
-        status_on: '&b Bossbar &a eingeschaltet'
-        status_off: '&b Bossbar &c ausgeschaltet'
+        status_on: '<aqua>Bossbar </aqua><green>eingeschaltet</green>'
+        status_off: '<aqua>Bossbar </aqua><red>ausgeschaltet</red>'
       actionbar:
         description: "schaltet die Phasen-Aktionsleiste um"
-        status_on: "&b Action Bar &a eingeschaltet"
-        status_off: "&b Action Bar &c ausgeschaltet"
+        status_on: "<aqua>Action Bar </aqua><green>eingeschaltet</green>"
+        status_off: "<aqua>Action Bar </aqua><red>ausgeschaltet</red>"
       setcount:
         parameters: <Anzahl>
         description: Setzen Sie die Blockanzahl auf den zuvor abgeschlossenen Wert
-        set: '&a Zähler auf [number] gesetzt.'
-        too-high: '&c Das Maximum, das Sie festlegen können, ist [number]!'
+        set: '<green>Zähler auf [number] gesetzt.</green>'
+        too-high: '<red>Das Maximum, das Sie festlegen können, ist [number]!</red>'
     respawn-block:
       description: >-
         lässt den magischen Block in Situationen wieder erscheinen, in denen er
         verschwindet
-      block-exist: >-
-        &ein Block existiert, musste nicht neu gestartet werden. Ich habe es für
-        dich markiert.
-      block-respawned: '&a Block wieder aufgetaucht.'
+      block-exist: '<yellow>in Block existiert, musste nicht neu gestartet werden. Ich habe es für dich markiert.</yellow>'
+      block-respawned: '<green>Block wieder aufgetaucht.</green>'
   phase:
-    insufficient-level: '&c Ihr Insellevel ist zu niedrig, um fortzufahren! Es muss [number] sein.'
-    insufficient-funds: '&c Ihr Guthaben ist zu gering, um fortzufahren! Sie müssen [number] sein.'
-    insufficient-bank-balance: >-
-      &c Der Saldo der Inselbank ist zu niedrig, um fortzufahren! Es muss
-      [number] sein.
-    insufficient-permission: >-
-      &c Sie können nicht weitermachen, bis Sie die [name]-Berechtigung
-      erhalten!
-    cooldown: '&c Die nächste Stufe ist in [number] Sekunden verfügbar!'
+    insufficient-level: '<red>Ihr Insellevel ist zu niedrig, um fortzufahren! Es muss [number] sein.</red>'
+    insufficient-funds: '<red>Ihr Guthaben ist zu gering, um fortzufahren! Sie müssen [number] sein.</red>'
+    insufficient-bank-balance: '<red>Der Saldo der Inselbank ist zu niedrig, um fortzufahren! Es muss [number] sein.</red>'
+    insufficient-permission: '<red>Sie können nicht weitermachen, bis Sie die [name]-Berechtigung erhalten!</red>'
+    cooldown: '<red>Die nächste Stufe ist in [number] Sekunden verfügbar!</red>'
   placeholders:
     infinite: Unendlich
     my-island-phase-default: Unbekannt
   gui:
     titles:
-      phases: '&0&l OneBlock-Phasen'
+      phases: '<black><bold>OneBlock-Phasen</bold></black>'
     buttons:
       previous:
-        name: '&f&l Vorherige Seite'
-        description: '&7 Zur Seite [number] wechseln'
+        name: '<white><bold>Vorherige Seite</bold></white>'
+        description: '<gray>Zur Seite [number] wechseln</gray>'
       next:
-        name: '&f&l Nächste Seite'
-        description: '&7 Zur Seite [number] wechseln'
+        name: '<white><bold>Nächste Seite</bold></white>'
+        description: '<gray>Zur Seite [number] wechseln</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -131,21 +119,21 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Startet nach dem Aufbrechen von &e [number] Blöcken.'
-        biome: '&7 Biom: &e [biome]'
-        bank: '&7 Erfordert &e $[number] &7 auf dem Bankkonto.'
-        economy: '&7 Erfordert &e $[number] &7 im Spielerkonto.'
-        level: '&7 Erfordert &e [number] &7 Inselebene.'
-        permission: '&7 Erfordert die Berechtigung „&e[permission]&7“.'
-        blocks-prefix: '&7 Blöcke in Phase -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Startet nach dem Aufbrechen von </gray><yellow>[number] Blöcken.</yellow>'
+        biome: '<gray>Biom: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Erfordert </gray><yellow>$[number] </yellow><gray>auf dem Bankkonto.</gray>'
+        economy: '<gray>Erfordert </gray><yellow>$[number] </yellow><gray>im Spielerkonto.</gray>'
+        level: '<gray>Erfordert </gray><yellow>[number] </yellow><gray>Inselebene.</gray>'
+        permission: '<gray>Erfordert die Berechtigung „</gray><yellow>[permission]</yellow><gray>“.</gray>'
+        blocks-prefix: '<gray>Blöcke in Phase -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Klicken Sie auf &7, um die vorherige Seite anzuzeigen.'
-      click-to-next: '&e Klicken Sie auf &7, um die nächste Seite anzuzeigen.'
-      click-to-change: '&e Zum Ändern &7klicken.'
+      click-to-previous: '<yellow>Klicken Sie auf </yellow><gray>, um die vorherige Seite anzuzeigen.</gray>'
+      click-to-next: '<yellow>Klicken Sie auf </yellow><gray>, um die nächste Seite anzuzeigen.</gray>'
+      click-to-change: '<yellow>Zum Ändern </yellow><gray>klicken.</gray>'
   island:
     starting-hologram: |-
-      &aWillkommen bei AOneBlock
-      &eBrechen Sie diesen Block,
-      &eum zu beginnen
+      <green>Willkommen bei AOneBlock
+      </green><yellow>Brechen Sie diesen Block,
+      um zu beginnen</yellow>

--- a/src/main/resources/locales/en-US.yml
+++ b/src/main/resources/locales/en-US.yml
@@ -8,149 +8,149 @@ protection:
     MAGIC_BLOCK:
       name: Magic Block Protection
       description: |-
-        &b Rank that can break the magic
-        &b block if they can break blocks.
-      hint: "&c Your rank cannot break the magic block!"
+        <aqua>Rank that can break the magic
+        block if they can break blocks.</aqua>
+      hint: "<red>Your rank cannot break the magic block!</red>"
     START_SAFETY:
       name: Starting Safety
       description: |-
-        &b Prevents new players
-        &b from moving for 1 minute
-        &b so they don't fall off.
-      hint: "&c Movement blocked for safety for [number] more seconds!"
-      free-to-move: "&a You are free to move. Be careful!"
+        <aqua>Prevents new players
+        from moving for 1 minute
+        so they don't fall off.</aqua>
+      hint: "<red>Movement blocked for safety for [number] more seconds!</red>"
+      free-to-move: "<green>You are free to move. Be careful!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Shows a status bar
-          &b for each phase.
+      name: Boss Bar
+      description: |-
+        <aqua>Shows a status bar
+        for each phase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Shows a status
-        &b for each phase
-        &b in the Action Bar.
+        <aqua>Shows a status
+        for each phase
+        in the Action Bar.</aqua>
 
 aoneblock:
   bossbar:
     title: "Blocks remaining"
     # status: "&a Phase blocks &b [total]. Blocks left: [todo]"
     # status: "&a [phase-name] : [percent-done]"
-    status: "&a Phase blocks &b [done] &d / &b [total]"
+    status: "<green>Phase blocks </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>"
     # RED, WHITE, PINK, BLUE, GREEN, YELLOW, or PURPLE
     color: RED
     # SOLID, SEGMENTED_6,  SEGMENTED_10, SEGMENTED_12, SEGMENTED_20
     style: SOLID
-    not-active: "&c Boss Bar is not active for this island"
+    not-active: "<red>Boss Bar is not active for this island</red>"
   actionbar:
-    status: "&a Phase: &b [phase-name] &d | &a Blocks: &b [done] &d / &b [total] &d | &a Progression: &b [percent-done]"
-    not-active: "&c Action Bar is not active for this island"
+    status: "<green>Phase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blocks: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Progression: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Action Bar is not active for this island</red>"
   commands:
     admin:
       setcount:
         parameters: "<name> <count> [lifetime]"
         description: "set player's block count"
-        set: "&a [name]'s count set to [number]"
-        set-lifetime: "&a [name]'s lifetime count set to [number]"
+        set: "<green>[name]'s count set to [number]</green>"
+        set-lifetime: "<green>[name]'s lifetime count set to [number]</green>"
       setchest:
         parameters: "<phase> <rarity>"
         description: "put the looked-at chest in a phase with the rarity specified"
-        chest-is-empty: "&c That chest is empty so cannot be added"
-        unknown-phase: "&c Unknown phase. Use tab-complete to see them"
-        unknown-rarity: "&c Unknown rarity. Use COMMON, UNCOMMON, RARE or EPIC"
-        look-at-chest: "&c Look at a filled chest to set it"
-        only-single-chest: "&c Only single chests can be set"
-        success: "&a Chest successfully added to phase"
-        failure: "&c Chest could not be added to the phase! See console for errors"
+        chest-is-empty: "<red>That chest is empty so cannot be added</red>"
+        unknown-phase: "<red>Unknown phase. Use tab-complete to see them</red>"
+        unknown-rarity: "<red>Unknown rarity. Use COMMON, UNCOMMON, RARE or EPIC</red>"
+        look-at-chest: "<red>Look at a filled chest to set it</red>"
+        only-single-chest: "<red>Only single chests can be set</red>"
+        success: "<green>Chest successfully added to phase</green>"
+        failure: "<red>Chest could not be added to the phase! See console for errors</red>"
       sanity:
         parameters: "<phase>"
         description: "display a sanity check of the phase probabilities in the console"
-        see-console: "&a See the console for the report"
+        see-console: "<green>See the console for the report</green>"
       phases:
         description: "open the phase order editor"
-        no-index: "&c No phase index is loaded, so phases cannot be reordered"
-        saved: "&a Phase order saved and applied"
-        save-failed: "&c Could not save the phase order! See console for errors"
+        no-index: "<red>No phase index is loaded, so phases cannot be reordered</red>"
+        saved: "<green>Phase order saved and applied</green>"
+        save-failed: "<red>Could not save the phase order! See console for errors</red>"
         gui:
-          title: "&2 Phase Order"
-          info-title: "&f How to use"
+          title: "<dark_green>Phase Order</dark_green>"
+          info-title: "<white>How to use</white>"
           instructions: |-
-            &7 Click a phase to pick it up,
-            &7 then click where it should go.
-            &7 Right-click toggles a phase
-            &7 on or off.
-          repeat: "&7 After the last phase the count jumps to &b [number]"
-          phase-name: "&a [name]"
-          start: "&7 Start: &b [number]"
-          length: "&7 Length: &b [number]"
-          disabled: "&c Disabled"
-          version-locked: "&c Needs Minecraft [version]+"
-          pick-up: "&e Click to move"
-          toggle: "&e Right-click to toggle"
-          set-length: "&e Shift-left-click to set length"
-          drop-here: "&e Click to drop here"
-          drop-at-end: "&a Drop at the end"
-          held: "&e Moving: [name]"
-          put-back: "&e Click to put back"
-          enter-length: "&e Enter a new length in chat for &a [name] &e - it is currently &b [number] &e blocks. Type &c cancel &e to keep it."
-          invalid-length: "&c The length must be a whole number above 0"
-          length-cancelled: "&c Length unchanged"
+            <gray>Click a phase to pick it up,
+            then click where it should go.
+            Right-click toggles a phase
+            on or off.</gray>
+          repeat: "<gray>After the last phase the count jumps to </gray><aqua>[number]</aqua>"
+          phase-name: "<green>[name]</green>"
+          start: "<gray>Start: </gray><aqua>[number]</aqua>"
+          length: "<gray>Length: </gray><aqua>[number]</aqua>"
+          disabled: "<red>Disabled</red>"
+          version-locked: "<red>Needs Minecraft [version]+</red>"
+          pick-up: "<yellow>Click to move</yellow>"
+          toggle: "<yellow>Right-click to toggle</yellow>"
+          set-length: "<yellow>Shift-left-click to set length</yellow>"
+          drop-here: "<yellow>Click to drop here</yellow>"
+          drop-at-end: "<green>Drop at the end</green>"
+          held: "<yellow>Moving: [name]</yellow>"
+          put-back: "<yellow>Click to put back</yellow>"
+          enter-length: "<yellow>Enter a new length in chat for </yellow><green>[name] </green><yellow>- it is currently </yellow><aqua>[number] </aqua><yellow>blocks. Type </yellow><red>cancel </red><yellow>to keep it.</yellow>"
+          invalid-length: "<red>The length must be a whole number above 0</red>"
+          length-cancelled: "<red>Length unchanged</red>"
           cancel-word: "cancel"
     count:
       description: show the block count and phase
-      info: "&a You are on block &b [number] in the &a [name] phase"
+      info: "<green>You are on block </green><aqua>[number] in the </aqua><green>[name] phase</green>"
     info:
-      count: "&a Island is on block &b [number] &a in the &b [name] &a phase. Lifetime count &b [lifetime] &a."
+      count: "<green>Island is on block </green><aqua>[number] </aqua><green>in the </green><aqua>[name] </aqua><green>phase. Lifetime count </green><aqua>[lifetime] </aqua><green>.</green>"
     phases:
       description: show a list of all the phases
-      title: "&2 OneBlock Phases"
-      name-syntax: "&a [name]"
-      description-syntax: "&b [number] blocks"
+      title: "<dark_green>OneBlock Phases</dark_green>"
+      name-syntax: "<green>[name]</green>"
+      description-syntax: "<aqua>[number] blocks</aqua>"
     island:
       bossbar:
         description: "toggles phase boss bar"
-        status_on: "&b Bossbar turned &a on"
-        status_off: "&b Bossbar turned &c off"
+        status_on: "<aqua>Bossbar turned </aqua><green>on</green>"
+        status_off: "<aqua>Bossbar turned </aqua><red>off</red>"
       actionbar:
         description: "toggles phase action bar"
-        status_on: "&b Action Bar turned &a on"
-        status_off: "&b Action Bar turned &c off"
+        status_on: "<aqua>Action Bar turned </aqua><green>on</green>"
+        status_off: "<aqua>Action Bar turned </aqua><red>off</red>"
       setcount:
         parameters: "<count>"
         description: "set block count to previously completed value"
-        set: "&a Count set to [number]."
-        too-high: "&c The maximum you can set is [number]!"
+        set: "<green>Count set to [number].</green>"
+        too-high: "<red>The maximum you can set is [number]!</red>"
     respawn-block:
       description: "respawns magic block in situations when it disappears"
-      block-exist: "&a Block exists, did not require respawning. I marked it for you."
-      block-respawned: "&a Block respawned."
+      block-exist: "<green>Block exists, did not require respawning. I marked it for you.</green>"
+      block-respawned: "<green>Block respawned.</green>"
   phase:
-    insufficient-level: "&c Your island level is too low to proceed! It must be [number]."
-    insufficient-funds: "&c Your funds are too low to proceed! They must be [number]."
-    insufficient-bank-balance: "&c The island bank balance is too low to proceed! It must be [number]."
-    insufficient-permission: "&c You can proceed no further until you obtain the [name] permission!"
-    cooldown: "&c Next phase will be available in [number] seconds!"
+    insufficient-level: "<red>Your island level is too low to proceed! It must be [number].</red>"
+    insufficient-funds: "<red>Your funds are too low to proceed! They must be [number].</red>"
+    insufficient-bank-balance: "<red>The island bank balance is too low to proceed! It must be [number].</red>"
+    insufficient-permission: "<red>You can proceed no further until you obtain the [name] permission!</red>"
+    cooldown: "<red>Next phase will be available in [number] seconds!</red>"
   placeholders:
     infinite: Infinite
     my-island-phase-default: Unknown
   gui:
     titles:
-      phases: '&0&l OneBlock Phases'
+      phases: '<black><bold>OneBlock Phases</bold></black>'
     # This section contains all button names and lore (description)
     buttons:
       # List of buttons in GUI's
       # Button that is used in multipage GUIs which allows to return to previous page.
       previous:
-        name: "&f&l Previous Page"
+        name: "<white><bold>Previous Page</bold></white>"
         description: |-
-          &7 Switch to [number] page
+          <gray>Switch to [number] page</gray>
       # Button that is used in multipage GUIs which allows to go to next page.
       next:
-        name: "&f&l Next Page"
+        name: "<white><bold>Next Page</bold></white>"
         description: |-
-          &7 Switch to [number] page
+          <gray>Switch to [number] page</gray>
       phase:
-        name: "&f&l [phase]"
+        name: "<white><bold>[phase]</bold></white>"
         description: |-
           [starting-block]
           [biome]
@@ -160,24 +160,24 @@ aoneblock:
           [permission]
           [blocks]
         # Replaces text with [starting-block]
-        starting-block: "&7 Starts after breaking &e [number] blocks."
+        starting-block: "<gray>Starts after breaking </gray><yellow>[number] blocks.</yellow>"
         # Replaces text with [biome]
-        biome: "&7 Biome: &e [biome]"
+        biome: "<gray>Biome: </gray><yellow>[biome]</yellow>"
         # Replaces text with [bank]
-        bank: "&7 Requires &e $[number] &7 in bank account."
+        bank: "<gray>Requires </gray><yellow>$[number] </yellow><gray>in bank account.</gray>"
         # Replaces text with [economy]
-        economy: "&7 Requires &e $[number] &7 in player account."
+        economy: "<gray>Requires </gray><yellow>$[number] </yellow><gray>in player account.</gray>"
         # Replaces text with [level]
-        level: "&7 Requires &e [number] &7 island level."
+        level: "<gray>Requires </gray><yellow>[number] </yellow><gray>island level.</gray>"
         # Replaces text with [permission]
-        permission: "&7 Requires `&e[permission]&7` permission."
+        permission: "<gray>Requires `</gray><yellow>[permission]</yellow><gray>` permission.</gray>"
         # Replaces text with [blocks]
-        blocks-prefix: '&7 Blocks in phase - '
-        blocks: '&e [name], '
+        blocks-prefix: '<gray>Blocks in phase - </gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: "&e Click &7 to view previous page."
-      click-to-next: "&e Click &7 to view next page."
-      click-to-change: "&e Click &7 to change."
+      click-to-previous: "<yellow>Click </yellow><gray>to view previous page.</gray>"
+      click-to-next: "<yellow>Click </yellow><gray>to view next page.</gray>"
+      click-to-change: "<yellow>Click </yellow><gray>to change.</gray>"
   island:
-    starting-hologram: "&aWelcome to AOneBlock\n&eBreak This Block to Begin"
+    starting-hologram: "<green>Welcome to AOneBlock\n</green><yellow>Break This Block to Begin</yellow>"

--- a/src/main/resources/locales/es.yml
+++ b/src/main/resources/locales/es.yml
@@ -3,121 +3,113 @@ protection:
     MAGIC_BLOCK:
       name: Protección de Bloque Mágico
       description: |-
-        &b Rango que puede romper el
-        &b bloque mágico si puede
-        &b romper bloques.
-      hint: "&c ¡Tu rango no puede romper el bloque mágico!"
+        <aqua>Rango que puede romper el
+        bloque mágico si puede
+        romper bloques.</aqua>
+      hint: "<red>¡Tu rango no puede romper el bloque mágico!</red>"
     START_SAFETY:
       name: Seguridad Inicial
       description: |-
-        &b Evita que los nuevos jugadores
-        &b se muevan durante 1 minuto
-        &b para que no se caigan.
-      hint: "&c Movimiento bloqueado por seguridad durante [number] segundos más!"
-      free-to-move: "&a Eres libre de moverte. ¡Ten cuidado!"
+        <aqua>Evita que los nuevos jugadores
+        se muevan durante 1 minuto
+        para que no se caigan.</aqua>
+      hint: "<red>Movimiento bloqueado por seguridad durante [number] segundos más!</red>"
+      free-to-move: "<green>Eres libre de moverte. ¡Ten cuidado!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Barra de Jefe (Boss Bar)
-        description: |-
-          &b Muestra una barra de estado
-          &b para cada fase.
+      name: Barra de Jefe (Boss Bar)
+      description: |-
+        <aqua>Muestra una barra de estado
+        para cada fase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Barra de Acción (Action Bar)
       description: |-
-        &b Muestra un estado
-        &b para cada fase
-        &b en la Barra de Acción.
+        <aqua>Muestra un estado
+        para cada fase
+        en la Barra de Acción.</aqua>
 aoneblock:
   bossbar:
     title: Bloques restantes
-    status: '&a Bloques de fase &b [done] &d / &b [total]'
+    status: '<green>Bloques de fase </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar no está activo para esta isla'
+    not-active: '<red>Boss Bar no está activo para esta isla</red>'
   actionbar:
-    status: "&a Fase: &b [phase-name] &d | &a Bloques: &b [done] &d / &b [total] &d | &a Progreso: &b [percent-done]"
-    not-active: "&c La barra de acción no está activa para esta isla"
+    status: "<green>Fase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Bloques: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Progreso: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>La barra de acción no está activa para esta isla</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count> [lifetime]
         description: Establece el número de bloques minados al jugador
-        set: '&aEl número de bloques minados de [name] se ha establecido en [number]'
-        set-lifetime: '&aEl numero de bloques totales de [name] se ha establecido en [number]'
+        set: '<green>El número de bloques minados de [name] se ha establecido en [number]</green>'
+        set-lifetime: '<green>El numero de bloques totales de [name] se ha establecido en [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: >-
           Coloca el cofre que estas mirando en una fase con la rareza
           especificada
-        chest-is-empty: '&cEse cofre está vacío, así que no se puede agregar'
-        unknown-phase: '&cFase desconocida. Presione TAB para verlas'
-        unknown-rarity: '&cRareza desconocida. Use COMMON, UNCOMMON, RARE o EPIC'
-        look-at-chest: '&cApunta hacia un cofre lleno para configurarlo'
-        only-single-chest: '&cSolo se pueden configurar cofres individuales'
-        success: '&aEl cofre ha sido agregado con éxito a la fase'
-        failure: >-
-          &c¡No se pudo agregar el cofre a la fase! Revisa la consola para más
-          detalles
+        chest-is-empty: '<red>Ese cofre está vacío, así que no se puede agregar</red>'
+        unknown-phase: '<red>Fase desconocida. Presione TAB para verlas</red>'
+        unknown-rarity: '<red>Rareza desconocida. Use COMMON, UNCOMMON, RARE o EPIC</red>'
+        look-at-chest: '<red>Apunta hacia un cofre lleno para configurarlo</red>'
+        only-single-chest: '<red>Solo se pueden configurar cofres individuales</red>'
+        success: '<green>El cofre ha sido agregado con éxito a la fase</green>'
+        failure: '<red>¡No se pudo agregar el cofre a la fase! Revisa la consola para más detalles</red>'
       sanity:
         parameters: <phase>
         description: >-
           Muestra una comprobación de las probabilidades de la fase en la
           consola
-        see-console: '&aRevisa la consola para ver el informe'
+        see-console: '<green>Revisa la consola para ver el informe</green>'
     count:
       description: Muestra el número de bloques minados y la fase correspondiente
-      info: '&aTienes &b[number] bloques minados en la fase &a[name]'
+      info: '<green>Tienes </green><aqua>[number] bloques minados en la fase </aqua><green>[name]</green>'
     info:
-      count: >-
-        &a Island está en el bloque &b [number]&a en la fase &b [name] &a.
-        Recuento de vida &b [lifetime] &a.
+      count: '<green>Island está en el bloque </green><aqua>[number]</aqua><green> en la fase </green><aqua>[name] </aqua><green>. Recuento de vida </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: Muestra una lista de todas las fases
-      title: '&2Fases de OneBlock'
-      name-syntax: '&a[name]'
-      description-syntax: '&b[number] bloques'
+      title: '<dark_green>Fases de OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] bloques</aqua>'
     island:
       bossbar:
         description: Barra de jefe de fase de alojamiento
-        status_on: '&b Bossbar &a encendió'
-        status_off: '&b Bossbar &a apagó'
+        status_on: '<aqua>Bossbar </aqua><green>encendió</green>'
+        status_off: '<aqua>Bossbar </aqua><green>apagó</green>'
       actionbar:
         description: alterna la barra de acción de fase
-        status_on: "&b Barra de acción &a activada"
-        status_off: "&b Barra de acción &c desactivada"
+        status_on: "<aqua>Barra de acción </aqua><green>activada</green>"
+        status_off: "<aqua>Barra de acción </aqua><red>desactivada</red>"
       setcount:
         parameters: <count>
         description: Establece la cantidad de bloques a un valor previamente completado
-        set: '&aCantidad establecida en [number].'
-        too-high: '&c¡Lo máximo que puedes establecer es [number]!'
+        set: '<green>Cantidad establecida en [number].</green>'
+        too-high: '<red>¡Lo máximo que puedes establecer es [number]!</red>'
     respawn-block:
       description: reaparece el bloque mágico en situaciones en las que desaparece
-      block-exist: '&a Block existe, no requirió reaparición. Te lo marqué.'
+      block-exist: '<green>Block existe, no requirió reaparición. Te lo marqué.</green>'
       block-respawned: '& un bloque reapareció.'
   phase:
-    insufficient-level: >-
-      &c¡Tu nivel de isla es demasiado bajo para seguir! Este debe ser de
-      [number].
-    insufficient-funds: '&c¡Tus fondos son insuficientes! Debes tener [number].'
-    insufficient-bank-balance: >-
-      &c¡El dinero del banco en la isla es demasiado bajo para seguir! Debes
-      tener [number].
-    insufficient-permission: '&c ¡No puede continuar hasta que obtenga el permiso de [name]!'
-    cooldown: '&c ¡La siguiente etapa estará disponible en [number] segundos!'
+    insufficient-level: '<red>¡Tu nivel de isla es demasiado bajo para seguir! Este debe ser de [number].</red>'
+    insufficient-funds: '<red>¡Tus fondos son insuficientes! Debes tener [number].</red>'
+    insufficient-bank-balance: '<red>¡El dinero del banco en la isla es demasiado bajo para seguir! Debes tener [number].</red>'
+    insufficient-permission: '<red>¡No puede continuar hasta que obtenga el permiso de [name]!</red>'
+    cooldown: '<red>¡La siguiente etapa estará disponible en [number] segundos!</red>'
   placeholders:
     infinite: Infinito
     my-island-phase-default: Desconocida
   gui:
     titles:
-      phases: '&0&l Fases de OneBlock'
+      phases: '<black><bold>Fases de OneBlock</bold></black>'
     buttons:
       previous:
-        name: '&f&l Pagina Anterior'
-        description: '&7 Ir a la pagina [number]'
+        name: '<white><bold>Pagina Anterior</bold></white>'
+        description: '<gray>Ir a la pagina [number]</gray>'
       next:
-        name: '&f&l Siguiente pagina'
-        description: '&7 Ir a la pagina [number]'
+        name: '<white><bold>Siguiente pagina</bold></white>'
+        description: '<gray>Ir a la pagina [number]</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -125,20 +117,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Comienza tras romper &e [number] bloques.'
-        biome: '&7 Bioma: &e [biome]'
-        bank: '&7 Requiere &e $[number] &7 en la cuenta del banco.'
-        economy: '&7 Requiere &e $[number] &7 en la cuenta del jugador.'
-        level: '&7 Requiere &e [number] &7 nivel de isla.'
-        permission: '&7 Requiere permiso `&e[permission]&7`.'
-        blocks-prefix: '&7 Bloques en fase -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Comienza tras romper </gray><yellow>[number] bloques.</yellow>'
+        biome: '<gray>Bioma: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Requiere </gray><yellow>$[number] </yellow><gray>en la cuenta del banco.</gray>'
+        economy: '<gray>Requiere </gray><yellow>$[number] </yellow><gray>en la cuenta del jugador.</gray>'
+        level: '<gray>Requiere </gray><yellow>[number] </yellow><gray>nivel de isla.</gray>'
+        permission: '<gray>Requiere permiso `</gray><yellow>[permission]</yellow><gray>`.</gray>'
+        blocks-prefix: '<gray>Bloques en fase -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Click &7 para ver pagina anterior.'
-      click-to-next: '&e Click &7 para ver pagina siguiente.'
-      click-to-change: '&e Click &7 para cambiar.'
+      click-to-previous: '<yellow>Click </yellow><gray>para ver pagina anterior.</gray>'
+      click-to-next: '<yellow>Click </yellow><gray>para ver pagina siguiente.</gray>'
+      click-to-change: '<yellow>Click </yellow><gray>para cambiar.</gray>'
   island:
     starting-hologram: |-
-      &aBienvenido a AOneBlock
-      &eRompe este bloque para empezar
+      <green>Bienvenido a AOneBlock
+      </green><yellow>Rompe este bloque para empezar</yellow>

--- a/src/main/resources/locales/fr.yml
+++ b/src/main/resources/locales/fr.yml
@@ -3,90 +3,86 @@ protection:
     MAGIC_BLOCK:
       name: Protection du Bloc Magique
       description: |-
-        &b Rang qui peut casser le bloc
-        &b magique s'il peut casser
-        &b des blocs.
-      hint: "&c Votre rang ne peut pas casser le bloc magique!"
+        <aqua>Rang qui peut casser le bloc
+        magique s'il peut casser
+        des blocs.</aqua>
+      hint: "<red>Votre rang ne peut pas casser le bloc magique!</red>"
     START_SAFETY:
       name: Sécurité de Départ
       description: |-
-        &b Empêche les nouveaux joueurs
-        &b de bouger pendant 1 minute
-        &b pour qu'ils ne tombent pas.
-      hint: "&c Mouvement bloqué par sécurité pendant [number] secondes supplémentaires!"
-      free-to-move: "&a Vous êtes libre de bouger. Faites attention!"
+        <aqua>Empêche les nouveaux joueurs
+        de bouger pendant 1 minute
+        pour qu'ils ne tombent pas.</aqua>
+      hint: "<red>Mouvement bloqué par sécurité pendant [number] secondes supplémentaires!</red>"
+      free-to-move: "<green>Vous êtes libre de bouger. Faites attention!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Barre de Boss
-        description: |-
-          &b Affiche une barre de statut
-          &b pour chaque phase.
+      name: Barre de Boss
+      description: |-
+        <aqua>Affiche une barre de statut
+        pour chaque phase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Barre d'Action
       description: |-
-        &b Affiche un statut
-        &b pour chaque phase
-        &b dans la Barre d'Action.
+        <aqua>Affiche un statut
+        pour chaque phase
+        dans la Barre d'Action.</aqua>
 aoneblock:
   bossbar:
     title: Blocs restants
-    status: '&a Blocs de phase &b [done] &d / &b [total]'
+    status: '<green>Blocs de phase </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar n''est pas actif pour cette île'
+    not-active: '<red>Boss Bar n''est pas actif pour cette île</red>'
   actionbar:
-    status: "&a Phase : &b [phase-name] &d | &a Blocs : &b [done] &d / &b [total] &d | &a Progression : &b [percent-done]"
-    not-active: "&c La barre d'action n'est pas active pour cette île"
+    status: "<green>Phase : </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blocs : </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Progression : </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>La barre d'action n'est pas active pour cette île</red>"
   commands:
     admin:
       setcount:
         parameters: <nom> <nombre> [DuréeDeVie]
         description: Définir le nombre de blocks du joueur
-        set: '&a Le compte de [name] est défini sur [number].'
-        set-lifetime: '&a La durée de vie de [name] est de [number]'
+        set: '<green>Le compte de [name] est défini sur [number].</green>'
+        set-lifetime: '<green>La durée de vie de [name] est de [number]</green>'
       setchest:
         parameters: <phase> <rareté>
         description: mettre le coffre regardé dans une phase avec la rareté spécifiée
-        chest-is-empty: '&c Ce coffre est vide donc il ne peut pas être ajouté'
-        unknown-phase: '&c Phase inconnue. Utilisez tab-complete pour les voir'
-        unknown-rarity: '&c Rareté inconnue. Utilisez COMMON, UNCOMMON, RARE ou EPIC'
-        look-at-chest: '&c Regardez un coffre rempli pour le placer'
-        only-single-chest: '&c Seuls les coffres simples peuvent être définis'
-        success: '&a Le coffre a été ajouté avec succès à la phase'
-        failure: >-
-          &c Le coffre n'a pas pu être ajouté à la phase! Voir la console pour
-          les erreurs
+        chest-is-empty: '<red>Ce coffre est vide donc il ne peut pas être ajouté</red>'
+        unknown-phase: '<red>Phase inconnue. Utilisez tab-complete pour les voir</red>'
+        unknown-rarity: '<red>Rareté inconnue. Utilisez COMMON, UNCOMMON, RARE ou EPIC</red>'
+        look-at-chest: '<red>Regardez un coffre rempli pour le placer</red>'
+        only-single-chest: '<red>Seuls les coffres simples peuvent être définis</red>'
+        success: '<green>Le coffre a été ajouté avec succès à la phase</green>'
+        failure: '<red>Le coffre n''a pas pu être ajouté à la phase! Voir la console pour les erreurs</red>'
       sanity:
         parameters: <phase>
         description: >-
           afficher un contrôle d'intégrité des probabilités de phase dans la
           console
-        see-console: '&a Voir la console pour le rapport'
+        see-console: '<green>Voir la console pour le rapport</green>'
     count:
       description: afficher le nombre de blocs et la phase
-      info: '&a Vous êtes sur le bloc &b [number] dans la phase &a [name]'
+      info: '<green>Vous êtes sur le bloc </green><aqua>[number] dans la phase </aqua><green>[name]</green>'
     info:
-      count: >-
-        &a L'île est sur le bloc &b [number]&a dans la phase &b [name] &a.
-        Nombre de durée de vie &b [lifetime] &a.
+      count: '<green>L''île est sur le bloc </green><aqua>[number]</aqua><green> dans la phase </green><aqua>[name] </aqua><green>. Nombre de durée de vie </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: afficher une liste de toutes les phases
-      title: '&2 Phases OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blocs'
+      title: '<dark_green>Phases OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blocs</aqua>'
     island:
       bossbar:
         description: bascule la barre de boss de phase
-        status_on: '&b Bossbar a &a activé'
-        status_off: '&b Bossbar &a désactivé'
+        status_on: '<aqua>Bossbar a </aqua><green>activé</green>'
+        status_off: '<aqua>Bossbar </aqua><green>désactivé</green>'
       actionbar:
         description: "active/désactive la barre d'action de phase"
-        status_on: "&b Barre d'action &a activée"
-        status_off: "&b Barre d'action &c désactivée"
+        status_on: "<aqua>Barre d'action </aqua><green>activée</green>"
+        status_off: "<aqua>Barre d'action </aqua><red>désactivée</red>"
       setcount:
         parameters: <compte>
         description: définir le nombre de blocs à la valeur précédemment terminée
-        set: '&a Nombre défini sur [number].'
-        too-high: "&c Le maximum que vous pouvez définir est [number]\_!"
+        set: '<green>Nombre défini sur [number].</green>'
+        too-high: "<red>Le maximum que vous pouvez définir est [number] !</red>"
     respawn-block:
       description: réapparaît le bloc magique dans les situations où il disparaît
       block-exist: >-
@@ -99,21 +95,21 @@ aoneblock:
     insufficient-bank-balance: >-
       Ta banque d'île n'a pas les fonds nécessaire ! Vous devez au moins avoir
       [number].
-    insufficient-permission: "&c Vous ne pouvez pas continuer jusqu'à ce que vous obteniez l'autorisation de [name]\_!"
-    cooldown: '&c La prochaine étape sera disponible dans [number] secondes!'
+    insufficient-permission: "<red>Vous ne pouvez pas continuer jusqu'à ce que vous obteniez l'autorisation de [name] !</red>"
+    cooldown: '<red>La prochaine étape sera disponible dans [number] secondes!</red>'
   placeholders:
     infinite: Infini
     my-island-phase-default: Inconnue
   gui:
     titles:
-      phases: '&0&l Phases OneBlock'
+      phases: '<black><bold>Phases OneBlock</bold></black>'
     buttons:
       previous:
-        name: '&f&l Page Précédente'
-        description: '&7 Aller à la page [number]'
+        name: '<white><bold>Page Précédente</bold></white>'
+        description: '<gray>Aller à la page [number]</gray>'
       next:
-        name: '&f&l Page Suivante'
-        description: '&7 Aller à la page [number]'
+        name: '<white><bold>Page Suivante</bold></white>'
+        description: '<gray>Aller à la page [number]</gray>'
       phase:
         name: '& l [phase]'
         description: |-
@@ -123,20 +119,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Commence après avoir détruit &e [number] blocs.'
-        biome: "&7 Biome\_: &e [biome]"
-        bank: '&7 Requiert &e $[number] &7 dans ta banque.'
-        economy: '&7 Requiert &e $[number] &7 dans ton solde.'
-        level: '&7 Requiert &e [number] &7 niveaux d''île.'
-        permission: '&7 Requiert la permission : `&e[permission]&7` .'
-        blocks-prefix: '&7 Blocs en phase -'
-        blocks: '&e [name],'
+        starting-block: '<gray>Commence après avoir détruit </gray><yellow>[number] blocs.</yellow>'
+        biome: "<gray>Biome : </gray><yellow>[biome]</yellow>"
+        bank: '<gray>Requiert </gray><yellow>$[number] </yellow><gray>dans ta banque.</gray>'
+        economy: '<gray>Requiert </gray><yellow>$[number] </yellow><gray>dans ton solde.</gray>'
+        level: '<gray>Requiert </gray><yellow>[number] </yellow><gray>niveaux d''île.</gray>'
+        permission: '<gray>Requiert la permission : `</gray><yellow>[permission]</yellow><gray>` .</gray>'
+        blocks-prefix: '<gray>Blocs en phase -</gray>'
+        blocks: '<yellow>[name],</yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Click &7 pour voir la page précédente.'
-      click-to-next: '&e Click &7 pour voir la page suivante.'
-      click-to-change: '&e Click &7 pour changer.'
+      click-to-previous: '<yellow>Click </yellow><gray>pour voir la page précédente.</gray>'
+      click-to-next: '<yellow>Click </yellow><gray>pour voir la page suivante.</gray>'
+      click-to-change: '<yellow>Click </yellow><gray>pour changer.</gray>'
   island:
     starting-hologram: |-
-      &aBienvenue sur AOneBlock
-      &eMine ce bloc pour commencer
+      <green>Bienvenue sur AOneBlock
+      </green><yellow>Mine ce bloc pour commencer</yellow>

--- a/src/main/resources/locales/hr.yml
+++ b/src/main/resources/locales/hr.yml
@@ -3,115 +3,109 @@ protection:
     MAGIC_BLOCK:
       name: Zaštita Magičnog Bloka
       description: |-
-        &b Rang koji može razbiti
-        &b magični blok, ako
-        &b može razbiti blokove.
-      hint: "&c Vaš rang ne može razbiti magični blok!"
+        <aqua>Rang koji može razbiti
+        magični blok, ako
+        može razbiti blokove.</aqua>
+      hint: "<red>Vaš rang ne može razbiti magični blok!</red>"
     START_SAFETY:
       name: Početna Sigurnost
       description: |-
-        &b Sprječava nove igrače
-        &b da se kreću 1 minutu
-        &b da ne padnu.
-      hint: "&c Kretanje je blokirano iz sigurnosnih razloga još [number] sekundi!"
-      free-to-move: "&a Slobodni ste za kretanje. Budite oprezni!"
+        <aqua>Sprječava nove igrače
+        da se kreću 1 minutu
+        da ne padnu.</aqua>
+      hint: "<red>Kretanje je blokirano iz sigurnosnih razloga još [number] sekundi!</red>"
+      free-to-move: "<green>Slobodni ste za kretanje. Budite oprezni!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Traka
-        description: |-
-          &b Prikazuje statusnu traku
-          &b za svaku fazu.
+      name: Boss Traka
+      description: |-
+        <aqua>Prikazuje statusnu traku
+        za svaku fazu.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Traka Akcije
       description: |-
-        &b Prikazuje status
-        &b za svaku fazu
-        &b u Traci Akcije.
+        <aqua>Prikazuje status
+        za svaku fazu
+        u Traci Akcije.</aqua>
 aoneblock:
   bossbar:
     title: Preostali blokovi
-    status: '&a Fazni blokovi &b [done] &d / &b [total]'
+    status: '<green>Fazni blokovi </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss bar nije aktivan za ovaj otok'
+    not-active: '<red>Boss bar nije aktivan za ovaj otok</red>'
   actionbar:
-    status: "&a Faza: &b [phase-name] &d | &a Blokovi: &b [done] &d / &b [total] &d | &a Napredak: &b [percent-done]"
-    not-active: "&c Akcijska traka nije aktivna za ovaj otok"
+    status: "<green>Faza: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blokovi: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Napredak: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Akcijska traka nije aktivna za ovaj otok</red>"
   commands:
     admin:
       setcount:
         parameters: <ime> <broj>
         description: postavljanje broja blokova igrača
-        set: '&a broj [name] postavljen je na [number]'
-        set-lifetime: '&broj životnog vijeka [name] postavljen na [number]'
+        set: '<green>broj [name] postavljen je na [number]</green>'
+        set-lifetime: '<aqua>roj životnog vijeka [name] postavljen na [number]</aqua>'
       setchest:
         parameters: <phase> <rarity>
         description: stavite pregledani sanduk u fazu s specificiranom rijetkošću
-        chest-is-empty: '&c Taj je škrinja prazna pa se ne može dodati'
-        unknown-phase: '&c Nepoznata faza. Da biste ih vidjeli, upotrijebite karticu'
-        unknown-rarity: '&c Nepoznata rijetkost. Koristite COMMON, UNCOMMON, RARE ili EPIC'
-        look-at-chest: '&c Pogledajte napunjen škrinju da ga postavite'
-        only-single-chest: '&c Mogu se postaviti samo pojedinačne škrinje'
-        success: '&a Komoda uspješno dodana u fazu'
-        failure: >-
-          &c Grudište se nije moglo dodati u fazu! Pogledajte konzolu za
-          pogreške
+        chest-is-empty: '<red>Taj je škrinja prazna pa se ne može dodati</red>'
+        unknown-phase: '<red>Nepoznata faza. Da biste ih vidjeli, upotrijebite karticu</red>'
+        unknown-rarity: '<red>Nepoznata rijetkost. Koristite COMMON, UNCOMMON, RARE ili EPIC</red>'
+        look-at-chest: '<red>Pogledajte napunjen škrinju da ga postavite</red>'
+        only-single-chest: '<red>Mogu se postaviti samo pojedinačne škrinje</red>'
+        success: '<green>Komoda uspješno dodana u fazu</green>'
+        failure: '<red>Grudište se nije moglo dodati u fazu! Pogledajte konzolu za pogreške</red>'
       sanity:
         parameters: <Faza>
         description: prikazati provjeru ispravnosti faznih vjerojatnosti u konzoli
-        see-console: '&a Pogledajte konzolu za izvješće'
+        see-console: '<green>Pogledajte konzolu za izvješće</green>'
     count:
       description: prikazuju broj i fazu bloka
-      info: '&a Nalazite se na bloku &b [number] u fazi &a [name]'
+      info: '<green>Nalazite se na bloku </green><aqua>[number] u fazi </aqua><green>[name]</green>'
     info:
-      count: >-
-        &a Otok je u bloku &b [number]&a u &b [name] &a fazi. Životni vijek &b
-        [lifetime] &a.
+      count: '<green>Otok je u bloku </green><aqua>[number]</aqua><green> u </green><aqua>[name] </aqua><green>fazi. Životni vijek </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: prikažite popis svih faza
-      title: '&2 OneBlock Faze'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blokova'
+      title: '<dark_green>OneBlock Faze</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blokova</aqua>'
     island:
       bossbar:
         description: prebacuje fazni boss bar
-        status_on: '&b Bossbar se &a uključio'
-        status_off: '&b Bossbar se &a isključio'
+        status_on: '<aqua>Bossbar se </aqua><green>uključio</green>'
+        status_off: '<aqua>Bossbar se </aqua><green>isključio</green>'
       actionbar:
         description: uključuje/isključuje akcijsku traku faze
-        status_on: "&b Akcijska traka &a uključena"
-        status_off: "&b Akcijska traka &c isključena"
+        status_on: "<aqua>Akcijska traka </aqua><green>uključena</green>"
+        status_off: "<aqua>Akcijska traka </aqua><red>isključena</red>"
       setcount:
         parameters: <count>
         description: postaviti broj blokova na prethodno dovršenu vrijednost
-        set: '&a Brojanje postavljeno na [number].'
-        too-high: '&c Maksimalno što možete postaviti je [number]!'
+        set: '<green>Brojanje postavljeno na [number].</green>'
+        too-high: '<red>Maksimalno što možete postaviti je [number]!</red>'
     respawn-block:
       description: ponovno rađa magični blok u situacijama kada nestane
-      block-exist: >-
-        &a blok postoji, nije zahtijevao ponovno stvaranje. Označila sam za
-        tebe.
-      block-respawned: '&a blok se ponovno pojavio.'
+      block-exist: '<green>blok postoji, nije zahtijevao ponovno stvaranje. Označila sam za tebe.</green>'
+      block-respawned: '<green>blok se ponovno pojavio.</green>'
   phase:
-    insufficient-level: '&c Vaša razina otoka je preniska za nastavak! Mora biti [number].'
-    insufficient-funds: '&c Vaša su sredstva premala za nastavak! Moraju biti [number].'
-    insufficient-bank-balance: '&c Stanje otočne banke je premalo za nastavak! Mora biti [number].'
-    insufficient-permission: '&c Ne možete nastaviti dok ne dobijete dopuštenje [name]!'
-    cooldown: '&c Sljedeća faza bit će dostupna za [number] sekundi!'
+    insufficient-level: '<red>Vaša razina otoka je preniska za nastavak! Mora biti [number].</red>'
+    insufficient-funds: '<red>Vaša su sredstva premala za nastavak! Moraju biti [number].</red>'
+    insufficient-bank-balance: '<red>Stanje otočne banke je premalo za nastavak! Mora biti [number].</red>'
+    insufficient-permission: '<red>Ne možete nastaviti dok ne dobijete dopuštenje [name]!</red>'
+    cooldown: '<red>Sljedeća faza bit će dostupna za [number] sekundi!</red>'
   placeholders:
     infinite: Beskonačno
     my-island-phase-default: Nepoznato
   gui:
     titles:
-      phases: '&0&l OneBlock faze'
+      phases: '<black><bold>OneBlock faze</bold></black>'
     buttons:
       previous:
-        name: '&f&l Prethodna stranica'
-        description: '&7 Prijeđi na stranicu [number].'
+        name: '<white><bold>Prethodna stranica</bold></white>'
+        description: '<gray>Prijeđi na stranicu [number].</gray>'
       next:
-        name: '&f&l Sljedeća stranica'
-        description: '&7 Prijeđi na stranicu [number].'
+        name: '<white><bold>Sljedeća stranica</bold></white>'
+        description: '<gray>Prijeđi na stranicu [number].</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -119,20 +113,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Počinje nakon razbijanja &e [number] blokova.'
-        biome: '&7 Biome: &e [biome]'
-        bank: '&7 Zahtijeva &e $[number] &7 na bankovnom računu.'
-        economy: '&7 Zahtijeva &e $[number] &7 na računu igrača.'
-        level: '&7 Zahtijeva &e [number] &7 razinu otoka.'
-        permission: '&7 Zahtijeva dozvolu `&e[permission]&7`.'
-        blocks-prefix: '&7 Blokovi u fazi -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Počinje nakon razbijanja </gray><yellow>[number] blokova.</yellow>'
+        biome: '<gray>Biome: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Zahtijeva </gray><yellow>$[number] </yellow><gray>na bankovnom računu.</gray>'
+        economy: '<gray>Zahtijeva </gray><yellow>$[number] </yellow><gray>na računu igrača.</gray>'
+        level: '<gray>Zahtijeva </gray><yellow>[number] </yellow><gray>razinu otoka.</gray>'
+        permission: '<gray>Zahtijeva dozvolu `</gray><yellow>[permission]</yellow><gray>`.</gray>'
+        blocks-prefix: '<gray>Blokovi u fazi -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Kliknite &7 za pregled prethodne stranice.'
-      click-to-next: '&e Kliknite &7 za pregled sljedeće stranice.'
-      click-to-change: '&e Kliknite &7 za promjenu.'
+      click-to-previous: '<yellow>Kliknite </yellow><gray>za pregled prethodne stranice.</gray>'
+      click-to-next: '<yellow>Kliknite </yellow><gray>za pregled sljedeće stranice.</gray>'
+      click-to-change: '<yellow>Kliknite </yellow><gray>za promjenu.</gray>'
   island:
     starting-hologram: |-
-      &aDobro došli u AOneBlock
-      &eRazbijte ovaj blok za početak
+      <green>Dobro došli u AOneBlock
+      </green><yellow>Razbijte ovaj blok za početak</yellow>

--- a/src/main/resources/locales/hu.yml
+++ b/src/main/resources/locales/hu.yml
@@ -3,118 +3,112 @@ protection:
     MAGIC_BLOCK:
       name: Mágikus Blokk Védelem
       description: |-
-        &b Rang, amely képes
-        &b szétrombolni a mágikus
-        &b blokkot, ha tud blokkokat
-        &b rombolni.
-      hint: "&c A rangod nem törheti szét a mágikus blokkot!"
+        <aqua>Rang, amely képes
+        szétrombolni a mágikus
+        blokkot, ha tud blokkokat
+        rombolni.</aqua>
+      hint: "<red>A rangod nem törheti szét a mágikus blokkot!</red>"
     START_SAFETY:
       name: Kezdő Biztonság
       description: |-
-        &b Megakadályozza az új játékosokat
-        &b a mozgásban 1 percig,
-        &b hogy ne essenek le.
-      hint: "&c Mozgás blokkolva biztonsági okokból még [number] másodpercig!"
-      free-to-move: "&a Szabadon mozoghatsz. Légy óvatos!"
+        <aqua>Megakadályozza az új játékosokat
+        a mozgásban 1 percig,
+        hogy ne essenek le.</aqua>
+      hint: "<red>Mozgás blokkolva biztonsági okokból még [number] másodpercig!</red>"
+      free-to-move: "<green>Szabadon mozoghatsz. Légy óvatos!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Állapotjelző sávot
-          &b mutat minden fázishoz.
+      name: Boss Bar
+      description: |-
+        <aqua>Állapotjelző sávot
+        mutat minden fázishoz.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Műveleti Sáv (Action Bar)
       description: |-
-        &b Állapotot mutat
-        &b minden fázishoz
-        &b a Műveleti Sávban.
+        <aqua>Állapotot mutat
+        minden fázishoz
+        a Műveleti Sávban.</aqua>
 aoneblock:
   bossbar:
     title: Blokkok maradtak
-    status: '&a Fázisblokkok &b [done] &d / &b [total]'
+    status: '<green>Fázisblokkok </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c A Boss Bar nem aktív ezen a szigeten'
+    not-active: '<red>A Boss Bar nem aktív ezen a szigeten</red>'
   actionbar:
-    status: "&a Fázis: &b [phase-name] &d | &a Blokkok: &b [done] &d / &b [total] &d | &a Haladás: &b [percent-done]"
-    not-active: "&c Az akciósáv nem aktív ezen a szigeten"
+    status: "<green>Fázis: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blokkok: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Haladás: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Az akciósáv nem aktív ezen a szigeten</red>"
   commands:
     admin:
       setcount:
         parameters: <név> <szám>
         description: állítsa be a játékos blokkszámát
-        set: '&a [name] számának beállítása erre: [number]'
-        set-lifetime: '&a [name] élettartama a következőre van állítva: [number]'
+        set: '<green>[name] számának beállítása erre: [number]</green>'
+        set-lifetime: '<green>[name] élettartama a következőre van állítva: [number]</green>'
       setchest:
         parameters: <fázis> <ritkaság>
         description: helyezze a nézett mellkasát egy szakaszba a megadott ritkasággal
-        chest-is-empty: '&c A mellkas üres, ezért nem adható hozzá'
-        unknown-phase: '&c Ismeretlen fázis. A Tab-Complete használatával megtekintheti őket'
-        unknown-rarity: '&c Ismeretlen ritkaság. Használjon COMMON, UNCOMMON, RARE vagy EPIC'
-        look-at-chest: '&c Nézzen meg egy töltött mellkasat, hogy beállítsa'
-        only-single-chest: '&c Csak egyetlen ládát lehet beállítani'
+        chest-is-empty: '<red>A mellkas üres, ezért nem adható hozzá</red>'
+        unknown-phase: '<red>Ismeretlen fázis. A Tab-Complete használatával megtekintheti őket</red>'
+        unknown-rarity: '<red>Ismeretlen ritkaság. Használjon COMMON, UNCOMMON, RARE vagy EPIC</red>'
+        look-at-chest: '<red>Nézzen meg egy töltött mellkasat, hogy beállítsa</red>'
+        only-single-chest: '<red>Csak egyetlen ládát lehet beállítani</red>'
         success: és egy mellkas sikeresen hozzáadva a fázishoz
-        failure: '&c A mellkas nem adható hozzá a fázishoz! A hibákat lásd a konzolon'
+        failure: '<red>A mellkas nem adható hozzá a fázishoz! A hibákat lásd a konzolon</red>'
       sanity:
         parameters: <Fázisban>
         description: >-
           jelenítse meg a fázis valószínűségeinek józanság-ellenőrzését a
           konzolban
-        see-console: '&a Lásd a jelentés konzolt'
+        see-console: '<green>Lásd a jelentés konzolt</green>'
     count:
       description: mutassa meg a blokkok számát és a fázist
-      info: '&a Ön a &b [number] blokkban van a &a [name] fázisban'
+      info: '<green>Ön a </green><aqua>[number] blokkban van a </aqua><green>[name] fázisban</green>'
     info:
-      count: >-
-        Az &a sziget a &b [number]&a blokkon található, a &b [name] &a fázisban.
-        Élettartam száma &b [lifetime] &a.
+      count: 'Az <green>sziget a </green><aqua>[number]</aqua><green> blokkon található, a </green><aqua>[name] </aqua><green>fázisban. Élettartam száma </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: az összes fázis felsorolása
-      title: '&2 OneBlock Fázis'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blokkolja'
+      title: '<dark_green>OneBlock Fázis</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blokkolja</aqua>'
     island:
       bossbar:
         description: váltók fázisú főnök sáv
-        status_on: '&b Bossbar &a bekapcsolt'
-        status_off: '&b Bossbar &c kikapcsolt'
+        status_on: '<aqua>Bossbar </aqua><green>bekapcsolt</green>'
+        status_off: '<aqua>Bossbar </aqua><red>kikapcsolt</red>'
       actionbar:
         description: fázis akciósáv ki/bekapcsolása
-        status_on: "&b Akciósáv &a bekapcsolva"
-        status_off: "&b Akciósáv &c kikapcsolva"
+        status_on: "<aqua>Akciósáv </aqua><green>bekapcsolva</green>"
+        status_off: "<aqua>Akciósáv </aqua><red>kikapcsolva</red>"
       setcount:
         parameters: <szám>
         description: állítsa be a blokkszámot a korábban kitöltött értékre
-        set: '&a A számláló értéke [szám].'
-        too-high: '&c A beállítható maximum [number]!'
+        set: '<green>A számláló értéke [szám].</green>'
+        too-high: '<red>A beállítható maximum [number]!</red>'
     respawn-block:
       description: varázsblokkot hoz újra olyan helyzetekben, amikor eltűnik
-      block-exist: '&a Blokk létezik, nem igényelt újbóli megjelenést. megjelöltem neked.'
-      block-respawned: '&a blokk újjáéledt.'
+      block-exist: '<green>Blokk létezik, nem igényelt újbóli megjelenést. megjelöltem neked.</green>'
+      block-respawned: '<green>blokk újjáéledt.</green>'
   phase:
-    insufficient-level: >-
-      &c A sziget szintje túl alacsony a folytatáshoz! Ennek a következőnek kell
-      lennie: [number].
-    insufficient-funds: '&c A kerete túl kevés a folytatáshoz! Ezeknek [number]-nak kell lenniük.'
-    insufficient-bank-balance: >-
-      &c A sziget banki egyenlege túl alacsony a folytatáshoz! Ennek a
-      következőnek kell lennie: [number].
-    insufficient-permission: '&c Nem folytathatja tovább, amíg meg nem szerzi a [name] engedélyt!'
-    cooldown: '&c A következő szakasz [number] másodpercen belül elérhető lesz!'
+    insufficient-level: '<red>A sziget szintje túl alacsony a folytatáshoz! Ennek a következőnek kell lennie: [number].</red>'
+    insufficient-funds: '<red>A kerete túl kevés a folytatáshoz! Ezeknek [number]-nak kell lenniük.</red>'
+    insufficient-bank-balance: '<red>A sziget banki egyenlege túl alacsony a folytatáshoz! Ennek a következőnek kell lennie: [number].</red>'
+    insufficient-permission: '<red>Nem folytathatja tovább, amíg meg nem szerzi a [name] engedélyt!</red>'
+    cooldown: '<red>A következő szakasz [number] másodpercen belül elérhető lesz!</red>'
   placeholders:
     infinite: Végtelen
     my-island-phase-default: Ismeretlen
   gui:
     titles:
-      phases: '&0&l OneBlock fázisok'
+      phases: '<black><bold>OneBlock fázisok</bold></black>'
     buttons:
       previous:
-        name: '&f&l Előző oldal'
-        description: '&7 Váltás a [number] oldalra'
+        name: '<white><bold>Előző oldal</bold></white>'
+        description: '<gray>Váltás a [number] oldalra</gray>'
       next:
-        name: '&f&l Következő oldal'
-        description: '&7 Váltás a [number] oldalra'
+        name: '<white><bold>Következő oldal</bold></white>'
+        description: '<gray>Váltás a [number] oldalra</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -122,20 +116,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Az &e [number] blokk feltörése után indul.'
-        biome: '&7 életrajz: &e [biome]'
-        bank: '&7 Szükséges &e $[number] &7 bankszámlára.'
-        economy: '&7 &e $[number] &7 játékos fiókot igényel.'
-        level: '&7 &e [number] &7 szigetszint szükséges.'
-        permission: '&7 `&e[permission]&7` engedély szükséges.'
-        blocks-prefix: '&7 Blokkok fázisban -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Az </gray><yellow>[number] blokk feltörése után indul.</yellow>'
+        biome: '<gray>életrajz: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Szükséges </gray><yellow>$[number] </yellow><gray>bankszámlára.</gray>'
+        economy: '<gray></gray><yellow>$[number] </yellow><gray>játékos fiókot igényel.</gray>'
+        level: '<gray></gray><yellow>[number] </yellow><gray>szigetszint szükséges.</gray>'
+        permission: '<gray>`</gray><yellow>[permission]</yellow><gray>` engedély szükséges.</gray>'
+        blocks-prefix: '<gray>Blokkok fázisban -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Kattintson a &7 gombra az előző oldal megtekintéséhez.'
-      click-to-next: '&e Kattintson a &7 gombra a következő oldal megtekintéséhez.'
-      click-to-change: '&e Kattintson a &7 gombra a módosításhoz.'
+      click-to-previous: '<yellow>Kattintson a </yellow><gray>gombra az előző oldal megtekintéséhez.</gray>'
+      click-to-next: '<yellow>Kattintson a </yellow><gray>gombra a következő oldal megtekintéséhez.</gray>'
+      click-to-change: '<yellow>Kattintson a </yellow><gray>gombra a módosításhoz.</gray>'
   island:
     starting-hologram: |-
-      &aÜdvözlünk az AOneBlockban
-      &eSzüntesse meg ezt a blokkot a kezdéshez
+      <green>Üdvözlünk az AOneBlockban
+      </green><yellow>Szüntesse meg ezt a blokkot a kezdéshez</yellow>

--- a/src/main/resources/locales/id.yml
+++ b/src/main/resources/locales/id.yml
@@ -3,97 +3,93 @@ protection:
     MAGIC_BLOCK:
       name: Perlindungan Blok Ajaib
       description: |-
-        &b Pangkat yang dapat
-        &b menghancurkan blok ajaib
-        &b jika mereka dapat menghancurkan blok.
-      hint: "&c Pangkatmu tidak dapat menghancurkan blok ajaib!"
+        <aqua>Pangkat yang dapat
+        menghancurkan blok ajaib
+        jika mereka dapat menghancurkan blok.</aqua>
+      hint: "<red>Pangkatmu tidak dapat menghancurkan blok ajaib!</red>"
     START_SAFETY:
       name: Keamanan Awal
       description: |-
-        &b Mencegah pemain baru
-        &b bergerak selama 1 menit
-        &b agar mereka tidak jatuh.
-      hint: "&c Pergerakan diblokir untuk keselamatan selama [number] detik lagi!"
-      free-to-move: "&a Anda bebas bergerak. Hati-hati!"
+        <aqua>Mencegah pemain baru
+        bergerak selama 1 menit
+        agar mereka tidak jatuh.</aqua>
+      hint: "<red>Pergerakan diblokir untuk keselamatan selama [number] detik lagi!</red>"
+      free-to-move: "<green>Anda bebas bergerak. Hati-hati!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Menampilkan bilah status
-          &b untuk setiap fase.
+      name: Boss Bar
+      description: |-
+        <aqua>Menampilkan bilah status
+        untuk setiap fase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Menampilkan status
-        &b untuk setiap fase
-        &b di Action Bar.
+        <aqua>Menampilkan status
+        untuk setiap fase
+        di Action Bar.</aqua>
 aoneblock:
   bossbar:
     title: Blok tersisa
-    status: Blok fase &b [done] &d / &b [total]
+    status: 'Blok fase <aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Bos Bar tidak aktif untuk pulau ini'
+    not-active: '<red>Bos Bar tidak aktif untuk pulau ini</red>'
   actionbar:
-    status: "&a Fase: &b [phase-name] &d | &a Blok: &b [done] &d / &b [total] &d | &a Kemajuan: &b [percent-done]"
-    not-active: "&c Action Bar tidak aktif untuk pulau ini"
+    status: "<green>Fase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blok: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Kemajuan: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Action Bar tidak aktif untuk pulau ini</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count>
         description: atur jumlah blok pemain
-        set: '&a hitungan [name] diatur ke [number]'
-        set-lifetime: '&a Hitungan seumur hidup [name] diatur ke [number]'
+        set: '<green>hitungan [name] diatur ke [number]</green>'
+        set-lifetime: '<green>Hitungan seumur hidup [name] diatur ke [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: letakkan dada yang tampak dalam fase dengan kelangkaan yang ditentukan
-        chest-is-empty: '&c Peti itu kosong sehingga tidak bisa ditambahkan'
-        unknown-phase: '&c Fase tidak dikenal. Gunakan tab-complete untuk melihatnya'
-        unknown-rarity: >-
-          &c Kelangkaan tidak diketahui. Gunakan COMMON, UNCOMMON, RARE atau
-          EPIC
-        look-at-chest: '&c Lihat peti berisi untuk mengaturnya'
-        only-single-chest: '&c Hanya peti tunggal yang dapat ditetapkan'
-        success: '&a Dada berhasil ditambahkan ke fase'
-        failure: '&c Dada tidak dapat ditambahkan ke fase! Lihat konsol untuk kesalahan'
+        chest-is-empty: '<red>Peti itu kosong sehingga tidak bisa ditambahkan</red>'
+        unknown-phase: '<red>Fase tidak dikenal. Gunakan tab-complete untuk melihatnya</red>'
+        unknown-rarity: '<red>Kelangkaan tidak diketahui. Gunakan COMMON, UNCOMMON, RARE atau EPIC</red>'
+        look-at-chest: '<red>Lihat peti berisi untuk mengaturnya</red>'
+        only-single-chest: '<red>Hanya peti tunggal yang dapat ditetapkan</red>'
+        success: '<green>Dada berhasil ditambahkan ke fase</green>'
+        failure: '<red>Dada tidak dapat ditambahkan ke fase! Lihat konsol untuk kesalahan</red>'
       sanity:
         parameters: <phase>
         description: menampilkan pemeriksaan kewarasan dari probabilitas fase di konsol
-        see-console: '&a Lihat konsol untuk laporannya'
+        see-console: '<green>Lihat konsol untuk laporannya</green>'
     count:
       description: perlihatkan jumlah blok dan fase
-      info: '&a Anda berada di blok &b [number] dalam fase &a [name]'
+      info: '<green>Anda berada di blok </green><aqua>[number] dalam fase </aqua><green>[name]</green>'
     info:
-      count: '&a Pulau ada di blok &b [number] &a dalam fase &b [name]. '
+      count: '<green>Pulau ada di blok </green><aqua>[number] </aqua><green>dalam fase </green><aqua>[name]. </aqua>'
     phases:
       description: perlihatkan daftar semua fase
-      title: '&2 Fase OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blok'
+      title: '<dark_green>Fase OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blok</aqua>'
     island:
       bossbar:
         description: Mengalogkan Bar Bos Fase
-        status_on: '&b Bos bar &a dihidupkan'
-        status_off: '&b Bos bar &c dimatikan'
+        status_on: '<aqua>Bos bar </aqua><green>dihidupkan</green>'
+        status_off: '<aqua>Bos bar </aqua><red>dimatikan</red>'
       actionbar:
         description: mengaktifkan/menonaktifkan action bar fase
-        status_on: "&b Action Bar &a diaktifkan"
-        status_off: "&b Action Bar &c dinonaktifkan"
+        status_on: "<aqua>Action Bar </aqua><green>diaktifkan</green>"
+        status_off: "<aqua>Action Bar </aqua><red>dinonaktifkan</red>"
       setcount:
         parameters: <count>
         description: Setel jumlah blok ke nilai yang sebelumnya selesai
-        set: '&a Hitung diatur ke [number].'
-        too-high: '&c Maksimum yang dapat Anda atur adalah [number]!'
+        set: '<green>Hitung diatur ke [number].</green>'
+        too-high: '<red>Maksimum yang dapat Anda atur adalah [number]!</red>'
     respawn-block:
       description: respawns blok ajaib dalam situasi saat menghilang
-      block-exist: '&a Blok ada, tidak memerlukan respawning. '
-      block-respawned: '&a Blokir dihidupkan kembali.'
+      block-exist: '<green>Blok ada, tidak memerlukan respawning. </green>'
+      block-respawned: '<green>Blokir dihidupkan kembali.</green>'
   phase:
-    insufficient-level: '&c Tingkat pulau Anda terlalu rendah untuk [number]! '
-    insufficient-funds: '&c Dana Anda terlalu rendah untuk [number]! '
-    insufficient-bank-balance: '&c Saldo bank pulau terlalu rendah untuk [number]! '
-    insufficient-permission: >-
-      &c Anda tidak dapat melanjutkan lebih jauh sampai Anda mendapatkan izin
-      [name]!
+    insufficient-level: '<red>Tingkat pulau Anda terlalu rendah untuk [number]! </red>'
+    insufficient-funds: '<red>Dana Anda terlalu rendah untuk [number]! </red>'
+    insufficient-bank-balance: '<red>Saldo bank pulau terlalu rendah untuk [number]! </red>'
+    insufficient-permission: '<red>Anda tidak dapat melanjutkan lebih jauh sampai Anda mendapatkan izin [name]!</red>'
     cooldown: Fase berikutnya akan tersedia dalam detik [number]!
   placeholders:
     infinite: Tak terbatas
@@ -103,13 +99,13 @@ aoneblock:
       phases: OneBlock Phases
     buttons:
       previous:
-        name: '&f&l  halaman sebelumnya'
-        description: '&7 Beralih ke halaman [number]'
+        name: '<white><bold> halaman sebelumnya</bold></white>'
+        description: '<gray>Beralih ke halaman [number]</gray>'
       next:
-        name: '&f&l halaman berikutnya'
-        description: '&7 Beralih ke halaman [number]'
+        name: '<white><bold>halaman berikutnya</bold></white>'
+        description: '<gray>Beralih ke halaman [number]</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -118,20 +114,20 @@ aoneblock:
           [level]
           [permission]
           [blocks]
-        starting-block: '&7 Dimulai setelah melanggar &e blok [number].'
-        biome: '&7 Biome: &e [biome]'
-        bank: '&7 Membutuhkan &e $[number] &7 di rekening bank.'
-        economy: '&7 Membutuhkan &e $[number] &7 di akun pemain.'
-        level: '&7 Membutuhkan tingkat pulau &e [number].'
-        permission: '&7 Membutuhkan izin &e `[permission]`.'
-        blocks-prefix: '&7 Blok dalam fase -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Dimulai setelah melanggar </gray><yellow>blok [number].</yellow>'
+        biome: '<gray>Biome: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Membutuhkan </gray><yellow>$[number] </yellow><gray>di rekening bank.</gray>'
+        economy: '<gray>Membutuhkan </gray><yellow>$[number] </yellow><gray>di akun pemain.</gray>'
+        level: '<gray>Membutuhkan tingkat pulau </gray><yellow>[number].</yellow>'
+        permission: '<gray>Membutuhkan izin </gray><yellow>`[permission]`.</yellow>'
+        blocks-prefix: '<gray>Blok dalam fase -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Klik &7 untuk melihat halaman sebelumnya.'
-      click-to-next: '&e Klik &7 untuk melihat halaman berikutnya.'
-      click-to-change: '&e Klik &7 untuk berubah.'
+      click-to-previous: '<yellow>Klik </yellow><gray>untuk melihat halaman sebelumnya.</gray>'
+      click-to-next: '<yellow>Klik </yellow><gray>untuk melihat halaman berikutnya.</gray>'
+      click-to-change: '<yellow>Klik </yellow><gray>untuk berubah.</gray>'
   island:
     starting-hologram: |-
-      &a Selamat datang di AONEBLOCK
-      &e Hancurkan blok ini untuk memulai
+      <green>Selamat datang di AONEBLOCK
+      </green><yellow>Hancurkan blok ini untuk memulai</yellow>

--- a/src/main/resources/locales/it.yml
+++ b/src/main/resources/locales/it.yml
@@ -3,113 +3,111 @@ protection:
     MAGIC_BLOCK:
       name: Protezione Blocco Magico
       description: |-
-        &b Rango che può rompere il
-        &b blocco magico se può
-        &b rompere i blocchi.
-      hint: "&c Il tuo rango non può rompere il blocco magico!"
+        <aqua>Rango che può rompere il
+        blocco magico se può
+        rompere i blocchi.</aqua>
+      hint: "<red>Il tuo rango non può rompere il blocco magico!</red>"
     START_SAFETY:
       name: Sicurezza Iniziale
       description: |-
-        &b Impedisce ai nuovi giocatori
-        &b di muoversi per 1 minuto
-        &b in modo che non cadano.
-      hint: "&c Movimento bloccato per sicurezza per [number] secondi ancora!"
-      free-to-move: "&a Sei libero di muoverti. Fai attenzione!"
+        <aqua>Impedisce ai nuovi giocatori
+        di muoversi per 1 minuto
+        in modo che non cadano.</aqua>
+      hint: "<red>Movimento bloccato per sicurezza per [number] secondi ancora!</red>"
+      free-to-move: "<green>Sei libero di muoverti. Fai attenzione!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Mostra una barra di stato
-          &b per ogni fase.
+      name: Boss Bar
+      description: |-
+        <aqua>Mostra una barra di stato
+        per ogni fase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Mostra uno stato
-        &b per ogni fase
-        &b nella Action Bar.
+        <aqua>Mostra uno stato
+        per ogni fase
+        nella Action Bar.</aqua>
 aoneblock:
   bossbar:
     title: Blocca i restanti
-    status: '&a Blocchi di fase &b [done] &d / &b [total]'
+    status: '<green>Blocchi di fase </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar non è attivo per quest''isola'
+    not-active: '<red>Boss Bar non è attivo per quest''isola</red>'
   actionbar:
-    status: "&a Fase: &b [phase-name] &d | &a Blocchi: &b [done] &d / &b [total] &d | &a Progresso: &b [percent-done]"
-    not-active: "&c La barra d'azione non è attiva per quest'isola"
+    status: "<green>Fase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blocchi: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Progresso: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>La barra d'azione non è attiva per quest'isola</red>"
   commands:
     admin:
       setcount:
         parameters: <nome> <conto>
         description: imposta il conteggio dei blocchi del giocatore
-        set: '&a il conteggio di [name] impostato su [number]'
-        set-lifetime: '&a Il conteggio della vita di [name] è impostato su [number]'
+        set: '<green>il conteggio di [name] impostato su [number]</green>'
+        set-lifetime: '<green>Il conteggio della vita di [name] è impostato su [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: mettere il torace osservato in una fase con la rarità specificata
-        chest-is-empty: '&c Quella cassa è vuota quindi non può essere aggiunta'
-        unknown-phase: '&c Fase sconosciuta. Usa tab-complete per vederli'
-        unknown-rarity: '&c Rarità sconosciuta. Utilizzare COMMON, UNCOMMON, RARE o EPIC'
-        look-at-chest: '&c Guarda una cassa piena per impostarla'
-        only-single-chest: '&c Possono essere impostati solo singoli forzieri'
-        success: '&a Una cassa aggiunta correttamente alla fase'
-        failure: '&c Chest non può essere aggiunto alla fase! Vedi console per errori'
+        chest-is-empty: '<red>Quella cassa è vuota quindi non può essere aggiunta</red>'
+        unknown-phase: '<red>Fase sconosciuta. Usa tab-complete per vederli</red>'
+        unknown-rarity: '<red>Rarità sconosciuta. Utilizzare COMMON, UNCOMMON, RARE o EPIC</red>'
+        look-at-chest: '<red>Guarda una cassa piena per impostarla</red>'
+        only-single-chest: '<red>Possono essere impostati solo singoli forzieri</red>'
+        success: '<green>Una cassa aggiunta correttamente alla fase</green>'
+        failure: '<red>Chest non può essere aggiunto alla fase! Vedi console per errori</red>'
       sanity:
         parameters: <Fase>
         description: >-
           visualizzare un controllo di integrità delle probabilità di fase nella
           console
-        see-console: '&a Vedi la console per il rapporto'
+        see-console: '<green>Vedi la console per il rapporto</green>'
     count:
       description: mostra il conteggio dei blocchi e la fase
-      info: '&a Sei sul blocco &b [number] nella fase &a [name]'
+      info: '<green>Sei sul blocco </green><aqua>[number] nella fase </aqua><green>[name]</green>'
     info:
-      count: >-
-        &a L'isola è in blocco &b [number] &a nella fase &b [name] &a. Lifetime
-        count &b [lifetime] &a.
+      count: '<green>L''isola è in blocco </green><aqua>[number] </aqua><green>nella fase </green><aqua>[name] </aqua><green>. Lifetime count </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: mostra un elenco di tutte le fasi
-      title: '&2 Fasi OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blocchi'
+      title: '<dark_green>Fasi OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blocchi</aqua>'
     island:
       bossbar:
         description: barra boss di fase di levetta
-        status_on: '&b Bossbar si è &a acceso'
-        status_off: '&b Bossbar si è &c spento'
+        status_on: '<aqua>Bossbar si è </aqua><green>acceso</green>'
+        status_off: '<aqua>Bossbar si è </aqua><red>spento</red>'
       actionbar:
         description: "attiva/disattiva la barra d'azione della fase"
-        status_on: "&b Barra d'azione &a attivata"
-        status_off: "&b Barra d'azione &c disattivata"
+        status_on: "<aqua>Barra d'azione </aqua><green>attivata</green>"
+        status_off: "<aqua>Barra d'azione </aqua><red>disattivata</red>"
       setcount:
         parameters: <count>
         description: Imposta il conteggio dei blocchi sul valore precedentemente completato
-        set: '&a Contare impostato su [number].'
-        too-high: '&c Il massimo che puoi impostare è [number]!'
+        set: '<green>Contare impostato su [number].</green>'
+        too-high: '<red>Il massimo che puoi impostare è [number]!</red>'
     respawn-block:
       description: Respira il blocco magico in situazioni quando scompare
-      block-exist: '&a Il blocco esiste, non ha richiesto il rigenerazione. '
-      block-respawned: '&a Blocco rigenerato.'
+      block-exist: '<green>Il blocco esiste, non ha richiesto il rigenerazione. </green>'
+      block-respawned: '<green>Blocco rigenerato.</green>'
   phase:
     insufficient-level: 'Il tuo livello dell''isola è troppo basso per procedere! '
     insufficient-funds: '& c i tuoi fondi sono troppo bassi per procedere!  Devono essere [number].'
-    insufficient-bank-balance: '&c The island bank balance is too low to proceed! It must be [number].'
-    insufficient-permission: '&c You can proceed no further until you obtain the [name] permission!'
-    cooldown: '&c Next phase will be available in [number] seconds!'
+    insufficient-bank-balance: '<red>The island bank balance is too low to proceed! It must be [number].</red>'
+    insufficient-permission: '<red>You can proceed no further until you obtain the [name] permission!</red>'
+    cooldown: '<red>Next phase will be available in [number] seconds!</red>'
   placeholders:
     infinite: Infinito
     my-island-phase-default: Sconosciuta
   gui:
     titles:
-      phases: '&0&l fasi di un blocco'
+      phases: '<black><bold>fasi di un blocco</bold></black>'
     buttons:
       previous:
         name: '& l pagina precedente'
-        description: '&7 Passa alla pagina [number]'
+        description: '<gray>Passa alla pagina [number]</gray>'
       next:
-        name: '&f&l Pagina successiva'
-        description: '&7 Passa alla pagina [number]'
+        name: '<white><bold>Pagina successiva</bold></white>'
+        description: '<gray>Passa alla pagina [number]</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -118,20 +116,20 @@ aoneblock:
           [level]
           [permission]
           [blocks]
-        starting-block: '&7 Inizia dopo aver rotto i blocchi &e [number].'
-        biome: '&7 Biome: &e [biome]'
-        bank: '&7 Richiede &e $ [number] &7 nel conto bancario.'
-        economy: '&7 Richiede &e $ [number] &7 nell''account giocatore.'
-        level: '&7 Richiede il livello &e [number] &7 dell''isola.'
-        permission: '&7 Richiede il permesso &e`[permission]`.'
-        blocks-prefix: '&7 Blocchi in fase -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Inizia dopo aver rotto i blocchi </gray><yellow>[number].</yellow>'
+        biome: '<gray>Biome: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Richiede </gray><yellow>$ [number] </yellow><gray>nel conto bancario.</gray>'
+        economy: '<gray>Richiede </gray><yellow>$ [number] </yellow><gray>nell''account giocatore.</gray>'
+        level: '<gray>Richiede il livello </gray><yellow>[number] </yellow><gray>dell''isola.</gray>'
+        permission: '<gray>Richiede il permesso </gray><yellow>`[permission]`.</yellow>'
+        blocks-prefix: '<gray>Blocchi in fase -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Fare clic &7 per visualizzare la pagina precedente.'
-      click-to-next: '&e Fare clic &7 per visualizzare la pagina successiva.'
-      click-to-change: '&e Fai clic &7 per cambiare.'
+      click-to-previous: '<yellow>Fare clic </yellow><gray>per visualizzare la pagina precedente.</gray>'
+      click-to-next: '<yellow>Fare clic </yellow><gray>per visualizzare la pagina successiva.</gray>'
+      click-to-change: '<yellow>Fai clic </yellow><gray>per cambiare.</gray>'
   island:
     starting-hologram: |-
-      &a Benvenuti in Aoneblock
-      &e Rompere questo blocco per iniziare
+      <green>Benvenuti in Aoneblock
+      </green><yellow>Rompere questo blocco per iniziare</yellow>

--- a/src/main/resources/locales/ja.yml
+++ b/src/main/resources/locales/ja.yml
@@ -3,46 +3,46 @@ protection:
     MAGIC_BLOCK:
       name: 魔法ブロック保護
       description: |-
-        &b ブロックを破壊できる場合、
-        &b 魔法ブロックを破壊できる
-        &b ランク。
-      hint: "&c あなたのランクでは魔法ブロックを破壊できません！"
+        <aqua>ブロックを破壊できる場合、
+        魔法ブロックを破壊できる
+        ランク。</aqua>
+      hint: "<red>あなたのランクでは魔法ブロックを破壊できません！</red>"
     START_SAFETY:
       name: 開始時の安全対策
       description: |-
-        &b 新しいプレイヤーが
-        &b 1分間移動するのを防ぎ、
-        &b 落下を防ぎます。
-      hint: "&c 安全のため、あと [number] 秒間移動がブロックされています！"
-      free-to-move: "&a 自由に動けます。注意してください！"
+        <aqua>新しいプレイヤーが
+        1分間移動するのを防ぎ、
+        落下を防ぎます。</aqua>
+      hint: "<red>安全のため、あと [number] 秒間移動がブロックされています！</red>"
+      free-to-move: "<green>自由に動けます。注意してください！</green>"
     ONEBLOCK_BOSSBAR:
-        name: ボスバー
-        description: |-
-          &b 各フェーズの
-          &b ステータスバーを表示します。
+      name: ボスバー
+      description: |-
+        <aqua>各フェーズの
+        ステータスバーを表示します。</aqua>
     ONEBLOCK_ACTIONBAR:
       name: アクションバー
       description: |-
-        &b 各フェーズの
-        &b ステータスを
-        &b アクションバーに表示します。
+        <aqua>各フェーズの
+        ステータスを
+        アクションバーに表示します。</aqua>
 aoneblock:
   bossbar:
     title: 残りのブロック
-    status: 位相ブロック &b [done] &d / &b [total]
+    status: '位相ブロック <aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c この島ではボスバーがアクティブではありません'
+    not-active: '<red>この島ではボスバーがアクティブではありません</red>'
   actionbar:
-    status: "&a フェーズ: &b [phase-name] &d | &a ブロック数: &b [done] &d / &b [total] &d | &a 進行状況: &b [percent-done]"
-    not-active: "&c この島ではアクションバーが有効ではありません"
+    status: "<green>フェーズ: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>ブロック数: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>進行状況: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>この島ではアクションバーが有効ではありません</red>"
   commands:
     admin:
       setcount:
         parameters: <名前> <数>
         description: プレイヤーのブロック数を設定する
         set: '[name]の数が[number]に設定されました'
-        set-lifetime: '&a [name] の有効期間カウントが [number] に設定されました'
+        set-lifetime: '<green>[name] の有効期間カウントが [number] に設定されました</green>'
       setchest:
         parameters: <フェーズ> <レア度>
         description: 見つめられた胸部を、指定された希少性を持つフェーズに置く
@@ -61,53 +61,51 @@ aoneblock:
       description: ブロック数とフェーズを表示する
       info: '[name]フェーズのブロック[number]にいます'
     info:
-      count: >-
-        &a 島は &b [name] &a フェーズのブロック &b [number]&a 上にあります。生涯カウント &b [lifetime]
-        &a。
+      count: '<green>島は </green><aqua>[name] </aqua><green>フェーズのブロック </green><aqua>[number]</aqua><green> 上にあります。生涯カウント </green><aqua>[lifetime] </aqua><green>。</green>'
     phases:
       description: すべてのフェーズのリストを表示する
       title: ＆2 OneBlockフェーズ
-      name-syntax: '&a[name]'
-      description-syntax: '&b [number]ブロック'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number]ブロック</aqua>'
     island:
       bossbar:
         description: トグルフェーズボスバー
-        status_on: '&b ボスバーが&a オン'
-        status_off: '&b ボスバーが&aオフ'
+        status_on: '<aqua>ボスバーが</aqua><green> オン</green>'
+        status_off: '<aqua>ボスバーが</aqua><green>オフ</green>'
       actionbar:
         description: フェーズアクションバーの切り替え
-        status_on: "&b アクションバーを &a オン &bにしました"
-        status_off: "&b アクションバーを &c オフ &bにしました"
+        status_on: "<aqua>アクションバーを </aqua><green>オン </green><aqua>にしました</aqua>"
+        status_off: "<aqua>アクションバーを </aqua><red>オフ </red><aqua>にしました</aqua>"
       setcount:
         parameters: <カウント>
         description: ブロック数を以前に完了した値に設定する
-        set: '&a カウントを [数値] に設定します。'
-        too-high: '&c 設定できる最大値は [number] です!'
+        set: '<green>カウントを [数値] に設定します。</green>'
+        too-high: '<red>設定できる最大値は [number] です!</red>'
     respawn-block:
       description: マジックブロックが消えた場合に再出現します
-      block-exist: '&a ブロックが存在します。再生成は必要ありませんでした。私はあなたのためにそれをマークしました。'
-      block-respawned: '&a ブロックが復活しました。'
+      block-exist: '<green>ブロックが存在します。再生成は必要ありませんでした。私はあなたのためにそれをマークしました。</green>'
+      block-respawned: '<green>ブロックが復活しました。</green>'
   phase:
-    insufficient-level: '&c 島のレベルが低すぎるので先に進めません! [number] である必要があります。'
-    insufficient-funds: '&c 資金が少なすぎるため続行できません。 [number] である必要があります。'
-    insufficient-bank-balance: '&c 島の銀行残高が少なすぎるため続行できません。 [number] である必要があります。'
-    insufficient-permission: '&c [name] の許可を取得するまで、これ以上先に進むことはできません。'
-    cooldown: '&c [number] 秒で次のステージへ!'
+    insufficient-level: '<red>島のレベルが低すぎるので先に進めません! [number] である必要があります。</red>'
+    insufficient-funds: '<red>資金が少なすぎるため続行できません。 [number] である必要があります。</red>'
+    insufficient-bank-balance: '<red>島の銀行残高が少なすぎるため続行できません。 [number] である必要があります。</red>'
+    insufficient-permission: '<red>[name] の許可を取得するまで、これ以上先に進むことはできません。</red>'
+    cooldown: '<red>[number] 秒で次のステージへ!</red>'
   placeholders:
     infinite: 無限
     my-island-phase-default: 不明
   gui:
     titles:
-      phases: '&0&l ワンブロックフェーズ'
+      phases: '<black><bold>ワンブロックフェーズ</bold></black>'
     buttons:
       previous:
-        name: '&f&l 前のページ'
-        description: '&7 [number]ページに切り替えます'
+        name: '<white><bold>前のページ</bold></white>'
+        description: '<gray>[number]ページに切り替えます</gray>'
       next:
-        name: '&f&l 次のページ'
-        description: '&7 [番号]ページに切り替えます'
+        name: '<white><bold>次のページ</bold></white>'
+        description: '<gray>[番号]ページに切り替えます</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -115,20 +113,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 &e [number] ブロックを分割した後に開始します。'
-        biome: '&7 バイオーム: &e [biome]'
-        bank: '&7 銀行口座に &e $[number] &7 が必要です。'
-        economy: '&7 プレイヤーアカウントに &e $[number] &7 が必要です。'
-        level: '&7 &e [number] &7 の島レベルが必要です。'
-        permission: '&7 `&e[permission]&7` 権限が必要です。'
-        blocks-prefix: '&7 フェーズのブロック - '
-        blocks: '&e [name], '
+        starting-block: '<gray></gray><yellow>[number] ブロックを分割した後に開始します。</yellow>'
+        biome: '<gray>バイオーム: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>銀行口座に </gray><yellow>$[number] </yellow><gray>が必要です。</gray>'
+        economy: '<gray>プレイヤーアカウントに </gray><yellow>$[number] </yellow><gray>が必要です。</gray>'
+        level: '<gray></gray><yellow>[number] </yellow><gray>の島レベルが必要です。</gray>'
+        permission: '<gray>`</gray><yellow>[permission]</yellow><gray>` 権限が必要です。</gray>'
+        blocks-prefix: '<gray>フェーズのブロック - </gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e &7 をクリックして前のページを表示します。'
-      click-to-next: '&e &7 をクリックして次のページを表示します。'
-      click-to-change: '&e &7 をクリックして変更します。'
+      click-to-previous: '<yellow></yellow><gray>をクリックして前のページを表示します。</gray>'
+      click-to-next: '<yellow></yellow><gray>をクリックして次のページを表示します。</gray>'
+      click-to-change: '<yellow></yellow><gray>をクリックして変更します。</gray>'
   island:
     starting-hologram: |-
-      &aAOneBlock へようこそ
-      &eこのブロックを壊して開始してください
+      <green>AOneBlock へようこそ
+      </green><yellow>このブロックを壊して開始してください</yellow>

--- a/src/main/resources/locales/pl.yml
+++ b/src/main/resources/locales/pl.yml
@@ -3,90 +3,88 @@ protection:
     MAGIC_BLOCK:
       name: Ochrona Magicznego Bloku
       description: |-
-        &b Ranga, która może zniszczyć
-        &b magiczny blok, jeśli
-        &b może niszczyć bloki.
-      hint: "&c Twoja ranga nie może zniszczyć magicznego bloku!"
+        <aqua>Ranga, która może zniszczyć
+        magiczny blok, jeśli
+        może niszczyć bloki.</aqua>
+      hint: "<red>Twoja ranga nie może zniszczyć magicznego bloku!</red>"
     START_SAFETY:
       name: Bezpieczeństwo Początkowe
       description: |-
-        &b Zapobiega poruszaniu się
-        &b nowym graczom przez 1 minutę,
-        &b aby nie spadli.
-      hint: "&c Ruch zablokowany ze względów bezpieczeństwa na kolejne [number] sekund!"
-      free-to-move: "&a Możesz się swobodnie poruszać. Bądź ostrożny!"
+        <aqua>Zapobiega poruszaniu się
+        nowym graczom przez 1 minutę,
+        aby nie spadli.</aqua>
+      hint: "<red>Ruch zablokowany ze względów bezpieczeństwa na kolejne [number] sekund!</red>"
+      free-to-move: "<green>Możesz się swobodnie poruszać. Bądź ostrożny!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Pasek Bossa
-        description: |-
-          &b Pokazuje pasek statusu
-          &b dla każdej fazy.
+      name: Pasek Bossa
+      description: |-
+        <aqua>Pokazuje pasek statusu
+        dla każdej fazy.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Pasek Akcji
       description: |-
-        &b Pokazuje status
-        &b dla każdej fazy
-        &b na Pasku Akcji.
+        <aqua>Pokazuje status
+        dla każdej fazy
+        na Pasku Akcji.</aqua>
 aoneblock:
   bossbar:
     title: Pozostałe bloki
-    status: '&a Bloki fazowe &b [done] &d / &b [total]'
+    status: '<green>Bloki fazowe </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar nie jest aktywny dla tej wyspy'
+    not-active: '<red>Boss Bar nie jest aktywny dla tej wyspy</red>'
   actionbar:
-    status: "&a Faza: &b [phase-name] &d | &a Bloki: &b [done] &d / &b [total] &d | &a Postęp: &b [percent-done]"
-    not-active: "&c Pasek akcji nie jest aktywny dla tej wyspy"
+    status: "<green>Faza: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Bloki: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Postęp: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Pasek akcji nie jest aktywny dla tej wyspy</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count>
         description: ustaw liczbę bloków gracza
-        set: '&a Liczba [name] została ustawiona na [number]'
-        set-lifetime: '&a [name] licznik życia ustawiony na [number]'
+        set: '<green>Liczba [name] została ustawiona na [number]</green>'
+        set-lifetime: '<green>[name] licznik życia ustawiony na [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: umieść oglądaną skrzynię w fazie o określonej rzadkości
-        chest-is-empty: '&cTa skrzynia jest pusta, więc nie można jej dodać'
-        unknown-phase: '&cNieznana faza. Aby uzupełnić, użyj tabulacji'
-        unknown-rarity: '&cNieznana rzadkość. Użyj COMMON, UNCOMMON, RARE lub EPIC'
-        look-at-chest: '&cSpójrz na wypełnioną skrzynię, aby ją ustawić'
-        only-single-chest: '&cMożna ustawić tylko pojedyncze skrzynie'
-        success: '&aSkrzynia pomyślnie dodana do fazy'
-        failure: '&cSkrzynia nie mogła zostać dodana do fazy! Zobacz błąd w konsoli'
+        chest-is-empty: '<red>Ta skrzynia jest pusta, więc nie można jej dodać</red>'
+        unknown-phase: '<red>Nieznana faza. Aby uzupełnić, użyj tabulacji</red>'
+        unknown-rarity: '<red>Nieznana rzadkość. Użyj COMMON, UNCOMMON, RARE lub EPIC</red>'
+        look-at-chest: '<red>Spójrz na wypełnioną skrzynię, aby ją ustawić</red>'
+        only-single-chest: '<red>Można ustawić tylko pojedyncze skrzynie</red>'
+        success: '<green>Skrzynia pomyślnie dodana do fazy</green>'
+        failure: '<red>Skrzynia nie mogła zostać dodana do fazy! Zobacz błąd w konsoli</red>'
       sanity:
         parameters: <faza>
         description: wyświetlać kontrolę poprawności prawdopodobieństwa fazy w konsoli
-        see-console: '&a Zobacz raport w konsoli'
+        see-console: '<green>Zobacz raport w konsoli</green>'
     count:
       description: pokaż liczbę bloków i fazę
-      info: '&a Jesteś na bloku &b [number] w fazie &a [name]'
+      info: '<green>Jesteś na bloku </green><aqua>[number] w fazie </aqua><green>[name]</green>'
     info:
-      count: >-
-        &a Wyspa jest na bloku &b [number] w fazie [name]. Lifetime count &b
-        [lifetime] &a.
+      count: '<green>Wyspa jest na bloku </green><aqua>[number] w fazie [name]. Lifetime count [lifetime] </aqua><green>.</green>'
     phases:
       description: pokaż listę wszystkich faz
-      title: '&2 Fazy OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] bloków'
+      title: '<dark_green>Fazy OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] bloków</aqua>'
     island:
       bossbar:
         description: Przełącza fazę boss
-        status_on: '&b Bossbar &a włączył'
-        status_off: '&b Bossbar &a wyłączył'
+        status_on: '<aqua>Bossbar </aqua><green>włączył</green>'
+        status_off: '<aqua>Bossbar </aqua><green>wyłączył</green>'
       actionbar:
         description: przełącza pasek akcji fazy
-        status_on: "&b Pasek akcji &a włączony"
-        status_off: "&b Pasek akcji &c wyłączony"
+        status_on: "<aqua>Pasek akcji </aqua><green>włączony</green>"
+        status_off: "<aqua>Pasek akcji </aqua><red>wyłączony</red>"
       setcount:
         parameters: <liczba>
         description: ustaw liczbę bloków na poprzednio uzupełnioną wartość
-        set: '&a Liczba ustawiona na [number].'
-        too-high: '&c Maksymalna wartość, jaką możesz ustawić, to [number]!'
+        set: '<green>Liczba ustawiona na [number].</green>'
+        too-high: '<red>Maksymalna wartość, jaką możesz ustawić, to [number]!</red>'
     respawn-block:
       description: odnawia magiczny blok, w przypadku zniknięcia
-      block-exist: '&a Blok nie potrzebował odnowienia. Został chwilowo zaznaczony'
-      block-respawned: '&a Odnowiono blok, proszę nie usuwaj go ponownie'
+      block-exist: '<green>Blok nie potrzebował odnowienia. Został chwilowo zaznaczony</green>'
+      block-respawned: '<green>Odnowiono blok, proszę nie usuwaj go ponownie</green>'
   phase:
     insufficient-level: Poziom Twojej wyspy jest za niski, aby kontynuować! Musi to być [number].
     insufficient-funds: Twoje fundusze są zbyt niskie, aby kontynuować! Musisz posiadać [number].
@@ -94,22 +92,22 @@ aoneblock:
       Saldo na rachunku bankowym wyspy jest zbyt niskie, aby kontynuować! Musi
       to być [number].
     insufficient-permission: Nie możesz kontynuować, dopóki nie uzyskasz pozwolenia [name]!
-    cooldown: '&c Następny etap będzie dostępny za [number] sekund!'
+    cooldown: '<red>Następny etap będzie dostępny za [number] sekund!</red>'
   placeholders:
     infinite: Nieskończony
     my-island-phase-default: Nieznana
   gui:
     titles:
-      phases: '&0&l Fazy OneBlock'
+      phases: '<black><bold>Fazy OneBlock</bold></black>'
     buttons:
       previous:
-        name: '&f&lNastępna strona'
-        description: '&7 Przeskocz do [number] strony'
+        name: '<white><bold>Następna strona</bold></white>'
+        description: '<gray>Przeskocz do [number] strony</gray>'
       next:
-        name: '&f&l Następna strona'
-        description: '&7 Przeskocz do [number] strony'
+        name: '<white><bold>Następna strona</bold></white>'
+        description: '<gray>Przeskocz do [number] strony</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -117,20 +115,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Rozpoczyna sie po&e [number] &7zniszczonych blokach.'
-        biome: '&7 Biom: &e [biome]'
-        bank: '&7 Potrzebujesz&e $[number] &7 na twoim koncie.'
-        economy: '&7 Potrzebujesz&e $[number] &7 na twoim koncie.'
-        level: '&7 Potrzebujesz &e [number] &7 poziom wyspy.'
-        permission: '&7 Wymaga uprawnienia `&e[permission]&7`.'
-        blocks-prefix: '&7 Bloki w fazie -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Rozpoczyna sie po</gray><yellow> [number] </yellow><gray>zniszczonych blokach.</gray>'
+        biome: '<gray>Biom: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Potrzebujesz</gray><yellow> $[number] </yellow><gray>na twoim koncie.</gray>'
+        economy: '<gray>Potrzebujesz</gray><yellow> $[number] </yellow><gray>na twoim koncie.</gray>'
+        level: '<gray>Potrzebujesz </gray><yellow>[number] </yellow><gray>poziom wyspy.</gray>'
+        permission: '<gray>Wymaga uprawnienia `</gray><yellow>[permission]</yellow><gray>`.</gray>'
+        blocks-prefix: '<gray>Bloki w fazie -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Kliknij &7, aby wyświetlić poprzednią stronę.'
-      click-to-next: '&e Kliknij &7, aby wyświetlić następną stronę.'
-      click-to-change: '&e Kliknij &7, aby zmienić.'
+      click-to-previous: '<yellow>Kliknij </yellow><gray>, aby wyświetlić poprzednią stronę.</gray>'
+      click-to-next: '<yellow>Kliknij </yellow><gray>, aby wyświetlić następną stronę.</gray>'
+      click-to-change: '<yellow>Kliknij </yellow><gray>, aby zmienić.</gray>'
   island:
     starting-hologram: |-
-      &aWitamy w OneBlock
-      &eZniszcz ten blok, aby rozpocząć
+      <green>Witamy w OneBlock
+      </green><yellow>Zniszcz ten blok, aby rozpocząć</yellow>

--- a/src/main/resources/locales/pt.yml
+++ b/src/main/resources/locales/pt.yml
@@ -3,98 +3,96 @@ protection:
     MAGIC_BLOCK:
       name: Proteção de Bloco Mágico
       description: |-
-        &b Rank que pode quebrar o
-        &b bloco mágico se puder
-        &b quebrar blocos.
-      hint: "&c Seu rank não pode quebrar o bloco mágico!"
+        <aqua>Rank que pode quebrar o
+        bloco mágico se puder
+        quebrar blocos.</aqua>
+      hint: "<red>Seu rank não pode quebrar o bloco mágico!</red>"
     START_SAFETY:
       name: Segurança Inicial
       description: |-
-        &b Impede que novos jogadores
-        &b se movam por 1 minuto
-        &b para que não caiam.
-      hint: "&c Movimento bloqueado por segurança por mais [number] segundos!"
-      free-to-move: "&a Você está livre para se mover. Tenha cuidado!"
+        <aqua>Impede que novos jogadores
+        se movam por 1 minuto
+        para que não caiam.</aqua>
+      hint: "<red>Movimento bloqueado por segurança por mais [number] segundos!</red>"
+      free-to-move: "<green>Você está livre para se mover. Tenha cuidado!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Mostra uma barra de status
-          &b para cada fase.
+      name: Boss Bar
+      description: |-
+        <aqua>Mostra uma barra de status
+        para cada fase.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Mostra um status
-        &b para cada fase
-        &b na Action Bar.
+        <aqua>Mostra um status
+        para cada fase
+        na Action Bar.</aqua>
 aoneblock:
   bossbar:
     title: Bloqueia o restante
-    status: '&a Blocos de fase &b [done] &d / &b [total]'
+    status: '<green>Blocos de fase </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c O Boss Bar não está ativo para esta ilha'
+    not-active: '<red>O Boss Bar não está ativo para esta ilha</red>'
   actionbar:
-    status: "&a Fase: &b [phase-name] &d | &a Blocos: &b [done] &d / &b [total] &d | &a Progresso: &b [percent-done]"
-    not-active: "&c A barra de ação não está ativa para esta ilha"
+    status: "<green>Fase: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Blocos: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Progresso: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>A barra de ação não está ativa para esta ilha</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count>
         description: definir contagem de blocos do jogador
-        set: '&a [name] contagem definida para [number]'
-        set-lifetime: '&a A contagem de vida útil [name] definida como [number]'
+        set: '<green>[name] contagem definida para [number]</green>'
+        set-lifetime: '<green>A contagem de vida útil [name] definida como [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: colocar o baú olhado em uma fase com a raridade especificada
-        chest-is-empty: '&c Esse baú está vazio, então não pode ser adicionado'
-        unknown-phase: '&c Fase desconhecida. Use tab-complete para vê-los'
-        unknown-rarity: '&c Raridade desconhecida. Use COMMON, UNCOMMON, RARE ou EPIC'
-        look-at-chest: '&c Olhe para um baú cheio para configurá-lo'
-        only-single-chest: '&c Apenas baús individuais podem ser ajustados'
-        success: '&a Baú adicionado com sucesso à fase'
-        failure: '&c O Bau não pôde ser adicionado à fase! Veja o console para erros'
+        chest-is-empty: '<red>Esse baú está vazio, então não pode ser adicionado</red>'
+        unknown-phase: '<red>Fase desconhecida. Use tab-complete para vê-los</red>'
+        unknown-rarity: '<red>Raridade desconhecida. Use COMMON, UNCOMMON, RARE ou EPIC</red>'
+        look-at-chest: '<red>Olhe para um baú cheio para configurá-lo</red>'
+        only-single-chest: '<red>Apenas baús individuais podem ser ajustados</red>'
+        success: '<green>Baú adicionado com sucesso à fase</green>'
+        failure: '<red>O Bau não pôde ser adicionado à fase! Veja o console para erros</red>'
       sanity:
         parameters: <phase>
         description: >-
           exibir uma verificação de sanidade das probabilidades de fase no
           console
-        see-console: '&a Veja o console para o relatório'
+        see-console: '<green>Veja o console para o relatório</green>'
     count:
       description: mostra a contagem de blocos e a fase
-      info: '&a Você está no bloco &b [number] no &a [name] fase'
+      info: '<green>Você está no bloco </green><aqua>[number] no </aqua><green>[name] fase</green>'
     info:
-      count: >-
-        &a A ilha está em bloco &b [number] &a na fase &b [name]. Lifetime count
-        &b [lifetime] &a.
+      count: '<green>A ilha está em bloco </green><aqua>[number] </aqua><green>na fase </green><aqua>[name]. Lifetime count [lifetime] </aqua><green>.</green>'
     phases:
       description: mostra uma lista de todas as fases
-      title: '&2 OneBlock Fases'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blocos'
+      title: '<dark_green>OneBlock Fases</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blocos</aqua>'
     island:
       bossbar:
         description: Alterna o Boss Boss Bar
-        status_on: '&b Bossbar &a ligado'
-        status_off: '&b Bossbar &c desligado'
+        status_on: '<aqua>Bossbar </aqua><green>ligado</green>'
+        status_off: '<aqua>Bossbar </aqua><red>desligado</red>'
       actionbar:
         description: alterna a barra de ação de fase
-        status_on: "&b Barra de ação &a ativada"
-        status_off: "&b Barra de ação &c desativada"
+        status_on: "<aqua>Barra de ação </aqua><green>ativada</green>"
+        status_off: "<aqua>Barra de ação </aqua><red>desativada</red>"
       setcount:
         parameters: <count>
         description: Defina a contagem de blocos para o valor previamente concluído
-        set: '&a Contagem definida como [number].'
-        too-high: '&c O máximo que você pode definir é [number]!'
+        set: '<green>Contagem definida como [number].</green>'
+        too-high: '<red>O máximo que você pode definir é [number]!</red>'
     respawn-block:
       description: Responda o bloco mágico em situações quando desaparece
-      block-exist: '&a O bloco existe, não exigiu reaparecimento. '
-      block-respawned: '&a Bloquear o reaparecido.'
+      block-exist: '<green>O bloco existe, não exigiu reaparecimento. </green>'
+      block-respawned: '<green>Bloquear o reaparecido.</green>'
   phase:
-    insufficient-level: '&c O nível da sua ilha é muito baixo para prosseguir! '
-    insufficient-funds: '&c Seus fundos são muito baixos para prosseguir! '
-    insufficient-bank-balance: '&c O saldo do banco da ilha é muito baixo para prosseguir! '
-    insufficient-permission: '&c Você não pode proceder mais até obter a permissão [name]!'
-    cooldown: '&c A próxima fase estará disponível em [number] segundos!'
+    insufficient-level: '<red>O nível da sua ilha é muito baixo para prosseguir! </red>'
+    insufficient-funds: '<red>Seus fundos são muito baixos para prosseguir! </red>'
+    insufficient-bank-balance: '<red>O saldo do banco da ilha é muito baixo para prosseguir! </red>'
+    insufficient-permission: '<red>Você não pode proceder mais até obter a permissão [name]!</red>'
+    cooldown: '<red>A próxima fase estará disponível em [number] segundos!</red>'
   placeholders:
     infinite: Infinito
     my-island-phase-default: Desconhecida
@@ -103,13 +101,13 @@ aoneblock:
       phases: Oneblock Fases
     buttons:
       previous:
-        name: '&f&l Página anterior'
-        description: '&7 Mudar para a página [number]'
+        name: '<white><bold>Página anterior</bold></white>'
+        description: '<gray>Mudar para a página [number]</gray>'
       next:
-        name: '&f&l Próxima página'
-        description: '&7 Mudar para a página [number]'
+        name: '<white><bold>Próxima página</bold></white>'
+        description: '<gray>Mudar para a página [number]</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -118,20 +116,20 @@ aoneblock:
           [level]
           [permission]
           [blocks]
-        starting-block: '&7 Começa após quebrar &e blocos [number].'
-        biome: '&7 Bioma: [biome]'
-        bank: '&7 Requer &e $ [number] &7 na conta bancária.'
-        economy: '&7 Requer &e $ [number] &7 na conta do jogador.'
-        level: '&7 Requer &e [number] &7 no nível da ilha.'
-        permission: '&7 Requer `&e[permission]&7` permissão.'
-        blocks-prefix: '&7 Blocos em fase -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Começa após quebrar </gray><yellow>blocos [number].</yellow>'
+        biome: '<gray>Bioma: [biome]</gray>'
+        bank: '<gray>Requer </gray><yellow>$ [number] </yellow><gray>na conta bancária.</gray>'
+        economy: '<gray>Requer </gray><yellow>$ [number] </yellow><gray>na conta do jogador.</gray>'
+        level: '<gray>Requer </gray><yellow>[number] </yellow><gray>no nível da ilha.</gray>'
+        permission: '<gray>Requer `</gray><yellow>[permission]</yellow><gray>` permissão.</gray>'
+        blocks-prefix: '<gray>Blocos em fase -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Clique &7 para visualizar a página anterior.'
-      click-to-next: '&e Clique &7 para visualizar a próxima página.'
-      click-to-change: '&e Clique &7 para alterar.'
+      click-to-previous: '<yellow>Clique </yellow><gray>para visualizar a página anterior.</gray>'
+      click-to-next: '<yellow>Clique </yellow><gray>para visualizar a próxima página.</gray>'
+      click-to-change: '<yellow>Clique </yellow><gray>para alterar.</gray>'
   island:
     starting-hologram: |-
-      &a Bem -vindo ao AOneBlock
-      &e Quebre este bloco para começar
+      <green>Bem -vindo ao AOneBlock
+      </green><yellow>Quebre este bloco para começar</yellow>

--- a/src/main/resources/locales/ru.yml
+++ b/src/main/resources/locales/ru.yml
@@ -36,9 +36,7 @@ aoneblock:
     style: SOLID
     not-active: <red>Боссбар отключен на этом острове.</red>
   actionbar:
-    status: '<green>Фаза: <aqua>[phase-name]</aqua> <light_purple>|</light_purple>
-      Блоков: <aqua>[done] <light_purple>/</light_purple> [total]</aqua> <light_purple>|</light_purple>
-      Прогресс: <aqua>[percent-done]</aqua></green>'
+    status: '<green>Фаза: <aqua>[phase-name]</aqua> <light_purple>|</light_purple> Блоков: <aqua>[done] <light_purple>/</light_purple> [total]</aqua> <light_purple>|</light_purple> Прогресс: <aqua>[percent-done]</aqua></green>'
     not-active: <red>Панель действий отключена на этом острове.</red>
   commands:
     admin:

--- a/src/main/resources/locales/tr.yml
+++ b/src/main/resources/locales/tr.yml
@@ -3,113 +3,109 @@ protection:
     MAGIC_BLOCK:
       name: Büyülü Blok Koruması
       description: |-
-        &b Blokları kırabilirlerse
-        &b büyülü bloğu kırabilecek
-        &b rütbe.
-      hint: "&c Rütbeniz büyülü bloğu kıramaz!"
+        <aqua>Blokları kırabilirlerse
+        büyülü bloğu kırabilecek
+        rütbe.</aqua>
+      hint: "<red>Rütbeniz büyülü bloğu kıramaz!</red>"
     START_SAFETY:
       name: Başlangıç Güvenliği
       description: |-
-        &b Yeni oyuncuların 1 dakika
-        &b boyunca hareket etmesini
-        &b engelleyerek düşmelerini önler.
-      hint: "&c Güvenlik için hareket [number] saniye daha engellendi!"
-      free-to-move: "&a Serbestçe hareket edebilirsiniz. Dikkatli olun!"
+        <aqua>Yeni oyuncuların 1 dakika
+        boyunca hareket etmesini
+        engelleyerek düşmelerini önler.</aqua>
+      hint: "<red>Güvenlik için hareket [number] saniye daha engellendi!</red>"
+      free-to-move: "<green>Serbestçe hareket edebilirsiniz. Dikkatli olun!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Çubuğu
-        description: |-
-          &b Her aşama için bir
-          &b durum çubuğu gösterir.
+      name: Boss Çubuğu
+      description: |-
+        <aqua>Her aşama için bir
+        durum çubuğu gösterir.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Eylem Çubuğu (Action Bar)
       description: |-
-        &b Her aşama için bir
-        &b durumu Eylem Çubuğunda
-        &b gösterir.
+        <aqua>Her aşama için bir
+        durumu Eylem Çubuğunda
+        gösterir.</aqua>
 aoneblock:
   bossbar:
     title: Kalan bloklar
-    status: '&a Faz blokları &b [done] &d / &b [total]'
+    status: '<green>Faz blokları </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Patron Bar bu ada için aktif değil'
+    not-active: '<red>Patron Bar bu ada için aktif değil</red>'
   actionbar:
-    status: "&a Aşama: &b [phase-name] &d | &a Bloklar: &b [done] &d / &b [total] &d | &a İlerleme: &b [percent-done]"
-    not-active: "&c Bu ada için eylem çubuğu aktif değil"
+    status: "<green>Aşama: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Bloklar: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>İlerleme: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Bu ada için eylem çubuğu aktif değil</red>"
   commands:
     admin:
       setcount:
         parameters: <ad> <sayı> [lifetime]
         description: oyuncunun blok sayısını ayarla
-        set: '&a [name] ''ın sayısı [number] olarak ayarlandı'
-        set-lifetime: '&a [name]''nin toplam kırılan blok sayısı [number] olarak ayarlandı'
+        set: '<green>[name] ''ın sayısı [number] olarak ayarlandı</green>'
+        set-lifetime: '<green>[name]''nin toplam kırılan blok sayısı [number] olarak ayarlandı</green>'
       setchest:
         parameters: <aşama> <nadirlik>
         description: bakılan sandığı nadir görülen bir evreye koyar
-        chest-is-empty: '&c Bu sandık boş, bu yüzden eklenemez'
-        unknown-phase: >-
-          &c Bilinmeyen aşama. Bunları görmek için sekme-tamamlama özelliğini
-          kullanın
+        chest-is-empty: '<red>Bu sandık boş, bu yüzden eklenemez</red>'
+        unknown-phase: '<red>Bilinmeyen aşama. Bunları görmek için sekme-tamamlama özelliğini kullanın</red>'
         unknown-rarity: '& c Bilinmeyen nadirlik. COMMON, UNCOMMON, RARE veya EPIC kullanın'
-        look-at-chest: '&c Ayarlamak için dolu bir sandığa bakın'
-        only-single-chest: '&c Yalnızca tek sandık ayarlanabilir'
-        success: '&a Sandık aşamaya başarıyla eklendi'
-        failure: '&c Sandık aşamaya eklenemedi! Hatalar için konsola bakın'
+        look-at-chest: '<red>Ayarlamak için dolu bir sandığa bakın</red>'
+        only-single-chest: '<red>Yalnızca tek sandık ayarlanabilir</red>'
+        success: '<green>Sandık aşamaya başarıyla eklendi</green>'
+        failure: '<red>Sandık aşamaya eklenemedi! Hatalar için konsola bakın</red>'
       sanity:
         parameters: <Aşama>
         description: konsoldaki faz olasılıklarının akıl sağlığını kontrol etmek
-        see-console: '&a Rapor için konsola bakın'
+        see-console: '<green>Rapor için konsola bakın</green>'
     count:
       description: blok sayısını ve aşamayı göster
-      info: '&a [name] aşamasında blok &b [number] üzerindesiniz'
+      info: '<green>[name] aşamasında blok </green><aqua>[number] üzerindesiniz</aqua>'
     info:
-      count: >-
-        &a Ada blok sayısı &b [number]  &b [name] &a aşamasında. Toplam kırılan
-        blok &b [lifetime] &a.
+      count: '<green>Ada blok sayısı </green><aqua>[number]  [name] </aqua><green>aşamasında. Toplam kırılan blok </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: tüm aşamaların bir listesini göster
-      title: '&2 TekBlok Aşaması'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] blokları'
+      title: '<dark_green>TekBlok Aşaması</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] blokları</aqua>'
     island:
       bossbar:
         description: Faz patron çubuğunu değiştirir
-        status_on: '&b Bossbar &a açıldı'
-        status_off: '&b Bossbar &c kapandı'
+        status_on: '<aqua>Bossbar </aqua><green>açıldı</green>'
+        status_off: '<aqua>Bossbar </aqua><red>kapandı</red>'
       actionbar:
         description: aşama eylem çubuğunu açar/kapatır
-        status_on: "&b Eylem Çubuğu &a açıldı"
-        status_off: "&b Eylem Çubuğu &c kapatıldı"
+        status_on: "<aqua>Eylem Çubuğu </aqua><green>açıldı</green>"
+        status_off: "<aqua>Eylem Çubuğu </aqua><red>kapatıldı</red>"
       setcount:
         parameters: <say>
         description: blok sayısını önceden tamamlanmış değere ayarla
-        set: '&a Sayım [number] olarak ayarlandı.'
-        too-high: '&c Ayarlayabileceğiniz maksimum sayı [number]!'
+        set: '<green>Sayım [number] olarak ayarlandı.</green>'
+        too-high: '<red>Ayarlayabileceğiniz maksimum sayı [number]!</red>'
     respawn-block:
       description: Kaynak bloğunu kaybolma durumlarında yeniden doğurur
-      block-exist: '&a Kaynak bloğu yerinde senin için işaretledim.'
-      block-respawned: '&a Kaynak bloğu yeniden doğdu.'
+      block-exist: '<green>Kaynak bloğu yerinde senin için işaretledim.</green>'
+      block-respawned: '<green>Kaynak bloğu yeniden doğdu.</green>'
   phase:
-    insufficient-level: '&c Ada seviyeniz devam etmek için çok düşük! [number] olmalıdır.'
-    insufficient-funds: '&c Paranız devam etmek için çok düşük! [number] olmalıdırlar.'
-    insufficient-bank-balance: '&c Ada bankası bakiyesi devam etmek için çok düşük! [number] olmalıdır.'
-    insufficient-permission: '&c [name] iznini alana kadar devam edemezsiniz!'
-    cooldown: '&c Bir sonraki aşama [number] saniye içinde hazır olacak!'
+    insufficient-level: '<red>Ada seviyeniz devam etmek için çok düşük! [number] olmalıdır.</red>'
+    insufficient-funds: '<red>Paranız devam etmek için çok düşük! [number] olmalıdırlar.</red>'
+    insufficient-bank-balance: '<red>Ada bankası bakiyesi devam etmek için çok düşük! [number] olmalıdır.</red>'
+    insufficient-permission: '<red>[name] iznini alana kadar devam edemezsiniz!</red>'
+    cooldown: '<red>Bir sonraki aşama [number] saniye içinde hazır olacak!</red>'
   placeholders:
     infinite: Sonsuz
     my-island-phase-default: Bilinmiyor
   gui:
     titles:
-      phases: '&0&l TekBlok Aşamaları'
+      phases: '<black><bold>TekBlok Aşamaları</bold></black>'
     buttons:
       previous:
-        name: '&f&l Önceki Sayfa'
-        description: '&7 [number] Sayılı sayfaya geçer'
+        name: '<white><bold>Önceki Sayfa</bold></white>'
+        description: '<gray>[number] Sayılı sayfaya geçer</gray>'
       next:
-        name: '&f&l Sıradaki Sayfa '
-        description: '&7 [number] Sayılı sayfaya geçer'
+        name: '<white><bold>Sıradaki Sayfa </bold></white>'
+        description: '<gray>[number] Sayılı sayfaya geçer</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -118,20 +114,20 @@ aoneblock:
           [level]
           [permission]
           [blocks]
-        starting-block: '&7 &e [sayı] kadar blok kırdıktan sonra başlar.'
-        biome: '&7 Biome: &e [biome]'
-        bank: '&7 Banka hesabında &e $[number] &7 olması gerekli.'
-        economy: '&7 Bakiyenizin &e $[number] &7 olması gerekli.'
-        level: '&7 &e [sayı] &7 kadar ada seviyeniz olmalı.'
-        permission: '&7 `&e[izin]&7` izni gerektirir.'
-        blocks-prefix: '&7 Aşamadaki bloklar - '
-        blocks: '&e [name], '
+        starting-block: '<gray></gray><yellow>[sayı] kadar blok kırdıktan sonra başlar.</yellow>'
+        biome: '<gray>Biome: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Banka hesabında </gray><yellow>$[number] </yellow><gray>olması gerekli.</gray>'
+        economy: '<gray>Bakiyenizin </gray><yellow>$[number] </yellow><gray>olması gerekli.</gray>'
+        level: '<gray></gray><yellow>[sayı] </yellow><gray>kadar ada seviyeniz olmalı.</gray>'
+        permission: '<gray>`</gray><yellow>[izin]</yellow><gray>` izni gerektirir.</gray>'
+        blocks-prefix: '<gray>Aşamadaki bloklar - </gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Önceki sayfayı görüntülemek için &7 tıklayın.'
-      click-to-next: '&e Sonraki sayfayı görüntülemek için &7 tıklayın.'
-      click-to-change: '&e Değiştirmek için &7 tıklayın.'
+      click-to-previous: '<yellow>Önceki sayfayı görüntülemek için </yellow><gray>tıklayın.</gray>'
+      click-to-next: '<yellow>Sonraki sayfayı görüntülemek için </yellow><gray>tıklayın.</gray>'
+      click-to-change: '<yellow>Değiştirmek için </yellow><gray>tıklayın.</gray>'
   island:
     starting-hologram: |-
-      &aTekBlok'a Hoş Geldiniz
-      &eBaşlamak için Bu Bloğu Kırın
+      <green>TekBlok'a Hoş Geldiniz
+      </green><yellow>Başlamak için Bu Bloğu Kırın</yellow>

--- a/src/main/resources/locales/uk.yml
+++ b/src/main/resources/locales/uk.yml
@@ -3,115 +3,109 @@ protection:
     MAGIC_BLOCK:
       name: Захист Магічного Блоку
       description: |-
-        &b Ранг, який може зламати
-        &b магічний блок, якщо
-        &b може ламати блоки.
-      hint: "&c Ваш ранг не може зламати магічний блок!"
+        <aqua>Ранг, який може зламати
+        магічний блок, якщо
+        може ламати блоки.</aqua>
+      hint: "<red>Ваш ранг не може зламати магічний блок!</red>"
     START_SAFETY:
       name: Початкова Безпека
       description: |-
-        &b Запобігає руху нових гравців
-        &b протягом 1 хвилини,
-        &b щоб вони не впали.
-      hint: "&c Рух заблоковано з міркувань безпеки ще на [number] секунд!"
-      free-to-move: "&a Ви можете вільно рухатися. Будьте обережні!"
+        <aqua>Запобігає руху нових гравців
+        протягом 1 хвилини,
+        щоб вони не впали.</aqua>
+      hint: "<red>Рух заблоковано з міркувань безпеки ще на [number] секунд!</red>"
+      free-to-move: "<green>Ви можете вільно рухатися. Будьте обережні!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss Bar
-        description: |-
-          &b Показує панель стану
-          &b для кожної фази.
+      name: Boss Bar
+      description: |-
+        <aqua>Показує панель стану
+        для кожної фази.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Action Bar
       description: |-
-        &b Показує статус
-        &b для кожної фази
-        &b в Action Bar.
+        <aqua>Показує статус
+        для кожної фази
+        в Action Bar.</aqua>
 aoneblock:
   bossbar:
     title: Блоки, що залишилися
-    status: '&a Фазові блоки &b [done] &d / &b [total]'
+    status: '<green>Фазові блоки </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar не активний для цього острова'
+    not-active: '<red>Boss Bar не активний для цього острова</red>'
   actionbar:
-    status: "&a Фаза: &b [phase-name] &d | &a Блоки: &b [done] &d / &b [total] &d | &a Прогрес: &b [percent-done]"
-    not-active: "&c Панель дій не активна для цього острова"
+    status: "<green>Фаза: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Блоки: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Прогрес: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Панель дій не активна для цього острова</red>"
   commands:
     admin:
       setcount:
         parameters: <name> <count> [lifetime]
         description: встановити кількість блоків гравця
-        set: '&a [name] встановлено значення [number]'
-        set-lifetime: '&a [name] тривалість життя встановлено на [number]'
+        set: '<green>[name] встановлено значення [number]</green>'
+        set-lifetime: '<green>[name] тривалість життя встановлено на [number]</green>'
       setchest:
         parameters: <phase> <rarity>
         description: поставити скриню, на яку дивляться, у фазу з указаною рідкістю
-        chest-is-empty: '&c Ця скриня порожня, тому її неможливо додати'
-        unknown-phase: '&c Невідома фаза. Використовуйте Tab-complete, щоб побачити їх'
-        unknown-rarity: '&c Невідома рідкість. Використовуйте COMMON, UNCOMMON, RARE або EPIC'
-        look-at-chest: '&c Подивіться на заповнену скриню, щоб встановити її'
-        only-single-chest: '&c Можна встановити лише окремі скрині'
+        chest-is-empty: '<red>Ця скриня порожня, тому її неможливо додати</red>'
+        unknown-phase: '<red>Невідома фаза. Використовуйте Tab-complete, щоб побачити їх</red>'
+        unknown-rarity: '<red>Невідома рідкість. Використовуйте COMMON, UNCOMMON, RARE або EPIC</red>'
+        look-at-chest: '<red>Подивіться на заповнену скриню, щоб встановити її</red>'
+        only-single-chest: '<red>Можна встановити лише окремі скрині</red>'
         success: '& Скриню успішно додано до фази'
-        failure: '&c Скриня не може бути додана до фази! Перегляньте консоль для помилок'
+        failure: '<red>Скриня не може бути додана до фази! Перегляньте консоль для помилок</red>'
       sanity:
         parameters: <phase>
         description: відобразити перевірку працездатності ймовірностей фази на консолі
-        see-console: '&a Дивіться консоль для звіту'
+        see-console: '<green>Дивіться консоль для звіту</green>'
     count:
       description: показати кількість блоків і фазу
-      info: '&a Ви знаходитесь у блоці &b [number] у фазі &a [name].'
+      info: '<green>Ви знаходитесь у блоці </green><aqua>[number] у фазі </aqua><green>[name].</green>'
     info:
-      count: >-
-        &a Острів знаходиться на блоці &b [number]&a у фазі &b [name] &a.
-        Підрахунок тривалості життя &b [lifetime] &a.
+      count: '<green>Острів знаходиться на блоці </green><aqua>[number]</aqua><green> у фазі </green><aqua>[name] </aqua><green>. Підрахунок тривалості життя </green><aqua>[lifetime] </aqua><green>.</green>'
     phases:
       description: показати список усіх фаз
-      title: '&2 OneBlock фази'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] блоків'
+      title: '<dark_green>OneBlock фази</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] блоків</aqua>'
     island:
       bossbar:
         description: перемикає фазу боса
-        status_on: '&b Bossbar &a увімкнув'
-        status_off: '&b Bossbar &c вимкнувся'
+        status_on: '<aqua>Bossbar </aqua><green>увімкнув</green>'
+        status_off: '<aqua>Bossbar </aqua><red>вимкнувся</red>'
       actionbar:
         description: перемикає панель дій фази
-        status_on: "&b Панель дій &a увімкнена"
-        status_off: "&b Панель дій &c вимкнена"
+        status_on: "<aqua>Панель дій </aqua><green>увімкнена</green>"
+        status_off: "<aqua>Панель дій </aqua><red>вимкнена</red>"
       setcount:
         parameters: <count>
         description: встановити кількість блоків до попередньо завершеного значення
-        set: '&a Лічильник встановлено на [number].'
-        too-high: '&c Максимум, який ви можете встановити, це [number]!'
+        set: '<green>Лічильник встановлено на [number].</green>'
+        too-high: '<red>Максимум, який ви можете встановити, це [number]!</red>'
     respawn-block:
       description: відроджує магічний блок у ситуаціях, коли він зникає
-      block-exist: '&a Блок існує, не потребує відновлення. Я позначив це для вас.'
+      block-exist: '<green>Блок існує, не потребує відновлення. Я позначив це для вас.</green>'
       block-respawned: '& Блок відродився.'
   phase:
-    insufficient-level: >-
-      &c Рівень вашого острова занадто низький, щоб продовжити! Це має бути
-      [number].
-    insufficient-funds: '&c Ваших коштів занадто мало, щоб продовжити! Вони мають бути [number].'
-    insufficient-bank-balance: >-
-      &c Баланс острівного банку занадто низький, щоб продовжити! Це має бути
-      [number].
-    insufficient-permission: '&c Ви не можете продовжувати далі, доки не отримаєте дозвіл [name]!'
-    cooldown: '&c Наступна фаза буде доступна через [number] секунд!'
+    insufficient-level: '<red>Рівень вашого острова занадто низький, щоб продовжити! Це має бути [number].</red>'
+    insufficient-funds: '<red>Ваших коштів занадто мало, щоб продовжити! Вони мають бути [number].</red>'
+    insufficient-bank-balance: '<red>Баланс острівного банку занадто низький, щоб продовжити! Це має бути [number].</red>'
+    insufficient-permission: '<red>Ви не можете продовжувати далі, доки не отримаєте дозвіл [name]!</red>'
+    cooldown: '<red>Наступна фаза буде доступна через [number] секунд!</red>'
   placeholders:
     infinite: Нескінченний
     my-island-phase-default: Невідомо
   gui:
     titles:
-      phases: '&0&l Фази одного блоку'
+      phases: '<black><bold>Фази одного блоку</bold></black>'
     buttons:
       previous:
-        name: '&f&l Попередня сторінка'
-        description: '&7 Перейти на сторінку [number].'
+        name: '<white><bold>Попередня сторінка</bold></white>'
+        description: '<gray>Перейти на сторінку [number].</gray>'
       next:
-        name: '&f&l Наступна сторінка'
-        description: '&7 Перейти на сторінку [number].'
+        name: '<white><bold>Наступна сторінка</bold></white>'
+        description: '<gray>Перейти на сторінку [number].</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -119,20 +113,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 Запускається після розбиття &e [number] блоків.'
-        biome: '&7 Біом: &e [biome]'
-        bank: '&7 Потрібен &e $[number] &7 на банківському рахунку.'
-        economy: '&7 Потрібен &e $[number] &7 в обліковому записі гравця.'
-        level: '&7 Потрібен рівень острова &e [number] &7.'
-        permission: '&7 Потрібен дозвіл `&e[permission]&7`.'
+        starting-block: '<gray>Запускається після розбиття </gray><yellow>[number] блоків.</yellow>'
+        biome: '<gray>Біом: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Потрібен </gray><yellow>$[number] </yellow><gray>на банківському рахунку.</gray>'
+        economy: '<gray>Потрібен </gray><yellow>$[number] </yellow><gray>в обліковому записі гравця.</gray>'
+        level: '<gray>Потрібен рівень острова </gray><yellow>[number] </yellow><gray>.</gray>'
+        permission: '<gray>Потрібен дозвіл `</gray><yellow>[permission]</yellow><gray>`.</gray>'
         blocks-prefix: Блоки по фазі -
-        blocks: '&e [name], '
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Натисніть &7, щоб переглянути попередню сторінку.'
-      click-to-next: '&e Натисніть &7, щоб переглянути наступну сторінку.'
-      click-to-change: '&e Натисніть &7, щоб змінити.'
+      click-to-previous: '<yellow>Натисніть </yellow><gray>, щоб переглянути попередню сторінку.</gray>'
+      click-to-next: '<yellow>Натисніть </yellow><gray>, щоб переглянути наступну сторінку.</gray>'
+      click-to-change: '<yellow>Натисніть </yellow><gray>, щоб змінити.</gray>'
   island:
     starting-hologram: |-
-      &aЛаскаво просимо до AOneBlock
-      &eРозбийте цей блок, щоб почати
+      <green>Ласкаво просимо до AOneBlock
+      </green><yellow>Розбийте цей блок, щоб почати</yellow>

--- a/src/main/resources/locales/vi.yml
+++ b/src/main/resources/locales/vi.yml
@@ -3,92 +3,90 @@ protection:
     MAGIC_BLOCK:
       name: Bảo Vệ Khối Ma Thuật
       description: |-
-        &b Xếp hạng có thể phá
-        &b khối ma thuật nếu họ
-        &b có thể phá khối.
-      hint: "&c Xếp hạng của bạn không thể phá khối ma thuật!"
+        <aqua>Xếp hạng có thể phá
+        khối ma thuật nếu họ
+        có thể phá khối.</aqua>
+      hint: "<red>Xếp hạng của bạn không thể phá khối ma thuật!</red>"
     START_SAFETY:
       name: An Toàn Khởi Đầu
       description: |-
-        &b Ngăn người chơi mới
-        &b di chuyển trong 1 phút
-        &b để họ không bị rơi.
-      hint: "&c Di chuyển bị chặn vì lý do an toàn trong [number] giây nữa!"
-      free-to-move: "&a Bạn được phép di chuyển tự do. Hãy cẩn thận!"
+        <aqua>Ngăn người chơi mới
+        di chuyển trong 1 phút
+        để họ không bị rơi.</aqua>
+      hint: "<red>Di chuyển bị chặn vì lý do an toàn trong [number] giây nữa!</red>"
+      free-to-move: "<green>Bạn được phép di chuyển tự do. Hãy cẩn thận!</green>"
     ONEBLOCK_BOSSBAR:
-        name: Thanh Boss
-        description: |-
-          &b Hiển thị thanh trạng thái
-          &b cho mỗi giai đoạn.
+      name: Thanh Boss
+      description: |-
+        <aqua>Hiển thị thanh trạng thái
+        cho mỗi giai đoạn.</aqua>
     ONEBLOCK_ACTIONBAR:
       name: Thanh Hành Động (Action Bar)
       description: |-
-        &b Hiển thị trạng thái
-        &b cho mỗi giai đoạn
-        &b trên Thanh Hành Động.
+        <aqua>Hiển thị trạng thái
+        cho mỗi giai đoạn
+        trên Thanh Hành Động.</aqua>
 aoneblock:
   bossbar:
     title: Khối còn lại
-    status: '&a Khối pha &b [done] &d / &b [total]'
+    status: '<green>Khối pha </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c Boss Bar không hoạt động cho hòn đảo này'
+    not-active: '<red>Boss Bar không hoạt động cho hòn đảo này</red>'
   actionbar:
-    status: "&a Giai đoạn: &b [phase-name] &d | &a Khối: &b [done] &d / &b [total] &d | &a Tiến độ: &b [percent-done]"
-    not-active: "&c Thanh hành động không hoạt động cho hòn đảo này"
+    status: "<green>Giai đoạn: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>Khối: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>Tiến độ: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>Thanh hành động không hoạt động cho hòn đảo này</red>"
   commands:
     admin:
       setcount:
         parameters: <tên> <số>
         description: chỉnh số đếm khối của người chơi
-        set: '&a Số đếm khối của [name] được đặt thành [number]'
-        set-lifetime: '&a Bộ đếm thời gian tồn tại của [name] được đặt thành [number]'
+        set: '<green>Số đếm khối của [name] được đặt thành [number]</green>'
+        set-lifetime: '<green>Bộ đếm thời gian tồn tại của [name] được đặt thành [number]</green>'
       setchest:
         parameters: <giai đoạn> <độ hiếm>
         description: thêm rương đang nhìn vào một giai đoạn với độ hiếm được chỉ định
-        chest-is-empty: '&c Rương đó trống nên không thể thêm vào'
-        unknown-phase: '&c Giai đoạn chưa biết. Dùng TAB để xem chúng'
-        unknown-rarity: '&c Độ hiếm chưa biết. Sử dụng COMMON, UNCOMMON, RARE hoặc EPIC'
-        look-at-chest: '&c Nhìn vào một cái rương đầy để đặt nó'
-        only-single-chest: '&c Chỉ có thể đặt các rương đơn'
-        success: '&a Rương được thêm thành công vào giai đoạn'
-        failure: >-
-          &c Rương không thể được thêm vào giai đoạn! Xem bảng điều khiển để
-          biết lỗi
+        chest-is-empty: '<red>Rương đó trống nên không thể thêm vào</red>'
+        unknown-phase: '<red>Giai đoạn chưa biết. Dùng TAB để xem chúng</red>'
+        unknown-rarity: '<red>Độ hiếm chưa biết. Sử dụng COMMON, UNCOMMON, RARE hoặc EPIC</red>'
+        look-at-chest: '<red>Nhìn vào một cái rương đầy để đặt nó</red>'
+        only-single-chest: '<red>Chỉ có thể đặt các rương đơn</red>'
+        success: '<green>Rương được thêm thành công vào giai đoạn</green>'
+        failure: '<red>Rương không thể được thêm vào giai đoạn! Xem bảng điều khiển để biết lỗi</red>'
       sanity:
         parameters: <giao đoạn>
         description: >-
           hiển thị kiểm tra sự đúng đắn của xác suất giao đoạn lên bảng điều
           khiển
-        see-console: '&a Xem bảng điều khiển cho báo cáo'
+        see-console: '<green>Xem bảng điều khiển cho báo cáo</green>'
     count:
       description: hiển thị số khối và giai đoạn
-      info: '&a Bạn đang ở trên khối &b [number] trong giai đoạn &a [name]'
+      info: '<green>Bạn đang ở trên khối </green><aqua>[number] trong giai đoạn </aqua><green>[name]</green>'
     info:
-      count: '&a Đảo nằm trên khối &b [number] &a trong giai đoạn &b [name]. '
+      count: '<green>Đảo nằm trên khối </green><aqua>[number] </aqua><green>trong giai đoạn </green><aqua>[name]. </aqua>'
     phases:
       description: hiển thị một danh sách tất cả các giai đoạn
-      title: '&2 Giai đoạn OneBlock'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number] khối'
+      title: '<dark_green>Giai đoạn OneBlock</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number] khối</aqua>'
     island:
       bossbar:
         description: bật thanh Boss giai đoạn
-        status_on: '&b Bossbar &a bật lên'
-        status_off: '&b Bossbar &c tắt'
+        status_on: '<aqua>Bossbar </aqua><green>bật lên</green>'
+        status_off: '<aqua>Bossbar </aqua><red>tắt</red>'
       actionbar:
         description: bật/tắt thanh hành động giai đoạn
-        status_on: "&b Thanh hành động đã &a bật"
-        status_off: "&b Thanh hành động đã &c tắt"
+        status_on: "<aqua>Thanh hành động đã </aqua><green>bật</green>"
+        status_off: "<aqua>Thanh hành động đã </aqua><red>tắt</red>"
       setcount:
         parameters: <số lượng>
         description: đặt số khối thành giá trị đã hoàn thành trước đó
-        set: '&a Bộ đếm được đặt thành [number].'
-        too-high: '&cMức tối đa bạn có thể đặt là[number]!'
+        set: '<green>Bộ đếm được đặt thành [number].</green>'
+        too-high: '<red>Mức tối đa bạn có thể đặt là[number]!</red>'
     respawn-block:
       description: Block ma thuật hồi sinh trong các tình huống khi nó biến mất
-      block-exist: '&a Khối tồn tại, không yêu cầu phản hồi. '
-      block-respawned: '&a Chặn hồi sinh.'
+      block-exist: '<green>Khối tồn tại, không yêu cầu phản hồi. </green>'
+      block-respawned: '<green>Chặn hồi sinh.</green>'
   phase:
     insufficient-level: Cấp đảo của bạn quá thấp để thực thi! Nó phải là [number].
     insufficient-funds: Tài chính của bạn quá thấp để thực thi! Nó phải là [number].
@@ -100,16 +98,16 @@ aoneblock:
     my-island-phase-default: Không xác định
   gui:
     titles:
-      phases: '&0&l Giai đoạn OneBlock'
+      phases: '<black><bold>Giai đoạn OneBlock</bold></black>'
     buttons:
       previous:
-        name: '&f&l Trang trước'
-        description: '&7 Chuyển sang trang [number]'
+        name: '<white><bold>Trang trước</bold></white>'
+        description: '<gray>Chuyển sang trang [number]</gray>'
       next:
-        name: '&f&l Trang tiếp theo'
+        name: '<white><bold>Trang tiếp theo</bold></white>'
         description: '& Chuyển sang trang [number]'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -118,20 +116,20 @@ aoneblock:
           [level]
           [permission]
           [blocks]
-        starting-block: '&7 Bắt đầu sau khi phá vỡ &e [number] khối.'
-        biome: '&7 Biome: &e [biome]'
-        bank: '&7 Yêu cầu 7e $[number] &7 trong tài khoản ngân hàng.'
-        economy: '&7 Yêu cầu &e $[number] &7 trong tài khoản người chơi.'
-        level: '&7 Yêu cầu &e[number] &7 cấp đảo.'
-        permission: '&7 Yêu cầu `&e[permission]&7` quyền.'
-        blocks-prefix: '&7 Khối trong giai đoạn -'
-        blocks: '&e [name], '
+        starting-block: '<gray>Bắt đầu sau khi phá vỡ </gray><yellow>[number] khối.</yellow>'
+        biome: '<gray>Biome: </gray><yellow>[biome]</yellow>'
+        bank: '<gray>Yêu cầu 7e $[number] trong tài khoản ngân hàng.</gray>'
+        economy: '<gray>Yêu cầu </gray><yellow>$[number] </yellow><gray>trong tài khoản người chơi.</gray>'
+        level: '<gray>Yêu cầu </gray><yellow>[number] </yellow><gray>cấp đảo.</gray>'
+        permission: '<gray>Yêu cầu `</gray><yellow>[permission]</yellow><gray>` quyền.</gray>'
+        blocks-prefix: '<gray>Khối trong giai đoạn -</gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e Bấm &7 để xem trang trước.'
-      click-to-next: '&e Bấm &7 để xem trang tiếp theo.'
-      click-to-change: '&e Bấm &7 để thay đổi.'
+      click-to-previous: '<yellow>Bấm </yellow><gray>để xem trang trước.</gray>'
+      click-to-next: '<yellow>Bấm </yellow><gray>để xem trang tiếp theo.</gray>'
+      click-to-change: '<yellow>Bấm </yellow><gray>để thay đổi.</gray>'
   island:
     starting-hologram: |-
-      &aChào mừng đến với OneBlock
-      &eĐập khối này để bắt đầu
+      <green>Chào mừng đến với OneBlock
+      </green><yellow>Đập khối này để bắt đầu</yellow>

--- a/src/main/resources/locales/zh-CN.yml
+++ b/src/main/resources/locales/zh-CN.yml
@@ -3,108 +3,108 @@ protection:
     MAGIC_BLOCK:
       name: 魔法方块保护
       description: |-
-        &b 如果玩家可以破坏方块，
-        &b 则该等级可以破坏
-        &b 魔法方块。
-      hint: "&c 您的等级无法破坏魔法方块！"
+        <aqua>如果玩家可以破坏方块，
+        则该等级可以破坏
+        魔法方块。</aqua>
+      hint: "<red>您的等级无法破坏魔法方块！</red>"
     START_SAFETY:
       name: 初始安全保护
       description: |-
-        &b 阻止新玩家在1分钟内
-        &b 移动，以防他们跌落。
-      hint: "&c 出于安全考虑，移动已被阻止 [number] 秒！"
-      free-to-move: "&a 您可以自由移动了。请小心！"
+        <aqua>阻止新玩家在1分钟内
+        移动，以防他们跌落。</aqua>
+      hint: "<red>出于安全考虑，移动已被阻止 [number] 秒！</red>"
+      free-to-move: "<green>您可以自由移动了。请小心！</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss 血条
-        description: |-
-          &b 为每个阶段
-          &b 显示一个状态条。
+      name: Boss 血条
+      description: |-
+        <aqua>为每个阶段
+        显示一个状态条。</aqua>
     ONEBLOCK_ACTIONBAR:
       name: 动作栏
       description: |-
-        &b 在动作栏中
-        &b 显示每个阶段
-        &b 的状态。
+        <aqua>在动作栏中
+        显示每个阶段
+        的状态。</aqua>
 aoneblock:
   bossbar:
     title: 剩余的块
-    status: '&a 相位块&b [done] &d / &b [total]'
+    status: '<green>相位块</green><aqua> [done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c 老板酒吧对这个岛不活跃'
+    not-active: '<red>老板酒吧对这个岛不活跃</red>'
   actionbar:
-    status: "&a 阶段: &b [phase-name] &d | &a 方块数: &b [done] &d / &b [total] &d | &a 进度: &b [percent-done]"
-    not-active: "&c 该岛屿的动作栏未激活"
+    status: "<green>阶段: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>方块数: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>进度: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>该岛屿的动作栏未激活</red>"
   commands:
     admin:
       setcount:
         parameters: <玩家名称> <数量>
         description: 设置玩家挖掘的方块数
-        set: '&a [name] 挖掘的方块数已设置为 [number]'
-        set-lifetime: '&a [name] 的重置次数已设置为 [number]'
+        set: '<green>[name] 挖掘的方块数已设置为 [number]</green>'
+        set-lifetime: '<green>[name] 的重置次数已设置为 [number]</green>'
       setchest:
         parameters: <阶段> <稀有度>
         description: 将您光标指向的箱子添加到一个阶段中, 并选择稀有度
-        chest-is-empty: '&c 该箱子无法添加, 因为它是空的'
-        unknown-phase: '&c 未知阶段. 用 Tab 补全来查看所有阶段'
-        unknown-rarity: '&c 未知稀有度. 可使用的有 COMMON, UNCOMMON, RARE 或 EPIC'
-        look-at-chest: '&c 将光标指向一个包含物品的箱子来设置它'
-        only-single-chest: '&c 只能设置单个箱子'
-        success: '&a 成功将箱子添加到该阶段'
-        failure: '&c 无法添加箱子到该阶段! 报错已在后台生成'
+        chest-is-empty: '<red>该箱子无法添加, 因为它是空的</red>'
+        unknown-phase: '<red>未知阶段. 用 Tab 补全来查看所有阶段</red>'
+        unknown-rarity: '<red>未知稀有度. 可使用的有 COMMON, UNCOMMON, RARE 或 EPIC</red>'
+        look-at-chest: '<red>将光标指向一个包含物品的箱子来设置它</red>'
+        only-single-chest: '<red>只能设置单个箱子</red>'
+        success: '<green>成功将箱子添加到该阶段</green>'
+        failure: '<red>无法添加箱子到该阶段! 报错已在后台生成</red>'
       sanity:
         parameters: <阶段>
         description: 在后台生成一份关于各阶段所占百分比的完整报告
-        see-console: '&a 报告已在后台生成'
+        see-console: '<green>报告已在后台生成</green>'
     count:
       description: 显示方块数量和阶段
-      info: '&a 您当前挖掘的方块数量是 &b [number], 为 &a [name] 阶段'
+      info: '<green>您当前挖掘的方块数量是 </green><aqua>[number], 为 </aqua><green>[name] 阶段</green>'
     info:
-      count: '&a 岛位于 &b [name] &a 阶段的 &b [number]&a 区块。生命周期计数 &b [lifetime] &a。'
+      count: '<green>岛位于 </green><aqua>[name] </aqua><green>阶段的 </green><aqua>[number]</aqua><green> 区块。生命周期计数 </green><aqua>[lifetime] </aqua><green>。</green>'
     phases:
       description: 显示所有阶段的列表
-      title: '&2 OneBlock 阶段'
-      name-syntax: '&a [name]'
-      description-syntax: '&b 挖掘了 [number] 个方块'
+      title: '<dark_green>OneBlock 阶段</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>挖掘了 [number] 个方块</aqua>'
     island:
       bossbar:
         description: 切换相位栏
-        status_on: '&b Bossbar turned &a on'
-        status_off: '&b Bossbar turned &c off'
+        status_on: '<aqua>Bossbar turned </aqua><green>on</green>'
+        status_off: '<aqua>Bossbar turned </aqua><red>off</red>'
       actionbar:
         description: 切换阶段动作栏
-        status_on: "&b 动作栏已 &a 开启"
-        status_off: "&b 动作栏已 &c 关闭"
+        status_on: "<aqua>动作栏已 </aqua><green>开启</green>"
+        status_off: "<aqua>动作栏已 </aqua><red>关闭</red>"
       setcount:
         parameters: <count>
         description: 将块计数设置为先前完成的值
-        set: '&a 数量设置为 [number].'
-        too-high: '&c 你最大只能设置 [number]!'
+        set: '<green>数量设置为 [number].</green>'
+        too-high: '<red>你最大只能设置 [number]!</red>'
     respawn-block:
       description: 在魔法块消失的情况下重生
-      block-exist: '&a 块存在，不需要重生。我给你标记了。'
-      block-respawned: '&a 块重生。'
+      block-exist: '<green>块存在，不需要重生。我给你标记了。</green>'
+      block-respawned: '<green>块重生。</green>'
   phase:
-    insufficient-level: '&c 岛屿等级过低, 无法执行此操作! 等级必须达到 [number].'
-    insufficient-funds: '&c 余额不足, 无法执行此操作! 余额应多于 [number].'
-    insufficient-bank-balance: '&c 岛屿银行余额不足, 无法执行此操作! 余额应多于 [number].'
-    insufficient-permission: '&c 在获得 [name] 许可之前，您不能继续操作！'
-    cooldown: '&c [number] 秒后即可进入下一阶段！'
+    insufficient-level: '<red>岛屿等级过低, 无法执行此操作! 等级必须达到 [number].</red>'
+    insufficient-funds: '<red>余额不足, 无法执行此操作! 余额应多于 [number].</red>'
+    insufficient-bank-balance: '<red>岛屿银行余额不足, 无法执行此操作! 余额应多于 [number].</red>'
+    insufficient-permission: '<red>在获得 [name] 许可之前，您不能继续操作！</red>'
+    cooldown: '<red>[number] 秒后即可进入下一阶段！</red>'
   placeholders:
     infinite: 无限
     my-island-phase-default: 未知
   gui:
     titles:
-      phases: '&0&l OneBlock 阶段'
+      phases: '<black><bold>OneBlock 阶段</bold></black>'
     buttons:
       previous:
-        name: '&f&l 上一页'
-        description: '&7 切换到[number]页'
+        name: '<white><bold>上一页</bold></white>'
+        description: '<gray>切换到[number]页</gray>'
       next:
-        name: '&f&l 下一页'
-        description: '&7 切换到[number]页'
+        name: '<white><bold>下一页</bold></white>'
+        description: '<gray>切换到[number]页</gray>'
       phase:
-        name: '&f&l [phase]'
+        name: '<white><bold>[phase]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -112,20 +112,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 在破坏 &e [number] 块后开始。'
-        biome: '&7 生物群落：&e [biome]'
-        bank: '&7 需要银行帐户中有 &e $[number] &7。'
-        economy: '&7 需要玩家帐户中有 &e $[number] &7。'
-        level: '&7 需要 &e [number] &7 岛屿等级。'
-        permission: '&7 需要 `&e[permission]&7` 权限。'
-        blocks-prefix: '&7 阶段块 - '
-        blocks: '&e [name], '
+        starting-block: '<gray>在破坏 </gray><yellow>[number] 块后开始。</yellow>'
+        biome: '<gray>生物群落：</gray><yellow> [biome]</yellow>'
+        bank: '<gray>需要银行帐户中有 </gray><yellow>$[number] </yellow><gray>。</gray>'
+        economy: '<gray>需要玩家帐户中有 </gray><yellow>$[number] </yellow><gray>。</gray>'
+        level: '<gray>需要 </gray><yellow>[number] </yellow><gray>岛屿等级。</gray>'
+        permission: '<gray>需要 `</gray><yellow>[permission]</yellow><gray>` 权限。</gray>'
+        blocks-prefix: '<gray>阶段块 - </gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e 单击&7 查看上一页。'
-      click-to-next: '&e 单击 &7 查看下一页。'
-      click-to-change: '&e 单击 &7 进行更改。'
+      click-to-previous: '<yellow>单击</yellow><gray> 查看上一页。</gray>'
+      click-to-next: '<yellow>单击 </yellow><gray>查看下一页。</gray>'
+      click-to-change: '<yellow>单击 </yellow><gray>进行更改。</gray>'
   island:
     starting-hologram: |-
-      &a欢迎来到 AOneBlock
-      &e破坏此方块以开始
+      <green>欢迎来到 AOneBlock
+      </green><yellow>破坏此方块以开始</yellow>

--- a/src/main/resources/locales/zh-TW.yml
+++ b/src/main/resources/locales/zh-TW.yml
@@ -3,138 +3,138 @@ protection:
     MAGIC_BLOCK:
       name: 魔法方塊保護
       description: |-
-        &b 如果玩家可以破壞方塊，
-        &b 則該等級可以破壞
-        &b 魔法方塊。
-      hint: "&c 你的等級無法破壞魔法方塊！"
+        <aqua>如果玩家可以破壞方塊，
+        則該等級可以破壞
+        魔法方塊。</aqua>
+      hint: "<red>你的等級無法破壞魔法方塊！</red>"
     START_SAFETY:
       name: 初始安全保護
       description: |-
-        &b 阻止新玩家在1分鐘內
-        &b 移動，以防他們跌落。
-      hint: "&c 為了安全考量，移動已被阻止 [number] 秒！"
-      free-to-move: "&a 你可以自由移動了，請小心！"
+        <aqua>阻止新玩家在1分鐘內
+        移動，以防他們跌落。</aqua>
+      hint: "<red>為了安全考量，移動已被阻止 [number] 秒！</red>"
+      free-to-move: "<green>你可以自由移動了，請小心！</green>"
     ONEBLOCK_BOSSBAR:
-        name: Boss 血條
-        description: |-
-          &b 為每個階段
-          &b 顯示一個狀態條。
+      name: Boss 血條
+      description: |-
+        <aqua>為每個階段
+        顯示一個狀態條。</aqua>
     ONEBLOCK_ACTIONBAR:
       name: 動作欄
       description: |-
-        &b 在動作欄中
-        &b 顯示每個階段
-        &b 的狀態。
+        <aqua>在動作欄中
+        顯示每個階段
+        的狀態。</aqua>
 aoneblock:
   bossbar:
     title: 剩餘方塊數
-    status: '&a 階段方塊&b [done] &d / &b [total]'
+    status: '<green>階段方塊</green><aqua> [done] </aqua><light_purple>/ </light_purple><aqua>[total]</aqua>'
     color: RED
     style: SEGMENTED_20
-    not-active: '&c 此島嶼的 Boss 血條未啟用'
+    not-active: '<red>此島嶼的 Boss 血條未啟用</red>'
   actionbar:
-    status: "&a 階段: &b [phase-name] &d | &a 方塊數: &b [done] &d / &b [total] &d | &a 進度: &b [percent-done]"
-    not-active: "&c 該島嶼的動作欄未啟用"
+    status: "<green>階段: </green><aqua>[phase-name] </aqua><light_purple>| </light_purple><green>方塊數: </green><aqua>[done] </aqua><light_purple>/ </light_purple><aqua>[total] </aqua><light_purple>| </light_purple><green>進度: </green><aqua>[percent-done]</aqua>"
+    not-active: "<red>該島嶼的動作欄未啟用</red>"
   commands:
     admin:
       setcount:
         parameters: <名稱> <計數>
         description: 設定玩家的方塊數量
-        set: '&a [name] 的計數設定為 [number]'
-        set-lifetime: '&a [name] 的生命週期計數設定為 [number]'
+        set: '<green>[name] 的計數設定為 [number]</green>'
+        set-lifetime: '<green>[name] 的生命週期計數設定為 [number]</green>'
       setchest:
         parameters: <階段> <稀有>
         description: 將所看的箱子放在指定稀有度的階段
-        chest-is-empty: '&c該箱子為空，因此無法添加'
-        unknown-phase: '&c未知階段。使用 Tab 鍵自動補全查看'
-        unknown-rarity: '&c未知稀有。使用COMMON，UNCOMMON，RARE或EPIC'
-        look-at-chest: '&c請看向裝滿的箱子'
-        only-single-chest: '&c只能設定單一箱子'
-        success: '&a 箱子成功添加'
-        failure: '&c 無法將箱子加入該階段！ 請參閱控制台以獲取錯誤'
+        chest-is-empty: '<red>該箱子為空，因此無法添加</red>'
+        unknown-phase: '<red>未知階段。使用 Tab 鍵自動補全查看</red>'
+        unknown-rarity: '<red>未知稀有。使用COMMON，UNCOMMON，RARE或EPIC</red>'
+        look-at-chest: '<red>請看向裝滿的箱子</red>'
+        only-single-chest: '<red>只能設定單一箱子</red>'
+        success: '<green>箱子成功添加</green>'
+        failure: '<red>無法將箱子加入該階段！ 請參閱控制台以獲取錯誤</red>'
       sanity:
         parameters: <階段>
         description: 在主控台顯示各階段機率的健全性檢查
-        see-console: '&a請參閱控制台以獲取報告'
+        see-console: '<green>請參閱控制台以獲取報告</green>'
       phases:
         description: 開啟階段順序編輯器
-        no-index: '&c 尚未載入階段索引，因此無法重新排序階段'
-        save-failed: '&c 無法儲存階段順序！請查看主控台錯誤訊息'
-        saved: '&a 階段順序已儲存並套用'
+        no-index: '<red>尚未載入階段索引，因此無法重新排序階段</red>'
+        save-failed: '<red>無法儲存階段順序！請查看主控台錯誤訊息</red>'
+        saved: '<green>階段順序已儲存並套用</green>'
         gui:
           cancel-word: 'cancel'
-          disabled: '&c 已停用'
-          drop-at-end: '&a 放到最後'
-          drop-here: '&e 點擊以放置於此'
-          enter-length: '&e 請在聊天室輸入 &a [name] &e 的新長度－目前為 &b [number] &e 個方塊。輸入 &c cancel &e 可保持不變。'
-          held: '&e 移動中：[name]'
-          info-title: '&f 使用方式'
+          disabled: '<red>已停用</red>'
+          drop-at-end: '<green>放到最後</green>'
+          drop-here: '<yellow>點擊以放置於此</yellow>'
+          enter-length: '<yellow>請在聊天室輸入 </yellow><green>[name] </green><yellow>的新長度－目前為 </yellow><aqua>[number] </aqua><yellow>個方塊。輸入 </yellow><red>cancel </red><yellow>可保持不變。</yellow>'
+          held: '<yellow>移動中：[name]</yellow>'
+          info-title: '<white>使用方式</white>'
           instructions: |-
-            &7 點擊一個階段以拿起它，
-            &7 再點擊要放置的位置。
-            &7 右鍵點擊可切換
-            &7 階段的啟用/停用。
-          invalid-length: '&c 長度必須是大於 0 的整數'
-          length: '&7 長度：&b [number]'
-          length-cancelled: '&c 長度未變更'
-          phase-name: '&a [name]'
-          pick-up: '&e 點擊以移動'
-          put-back: '&e 點擊以放回'
-          repeat: '&7 最後一個階段結束後，計數將跳至 &b [number]'
-          set-length: '&e Shift + 左鍵點擊以設定長度'
-          start: '&7 起始：&b [number]'
-          title: '&2 階段順序'
-          toggle: '&e 右鍵點擊以切換'
-          version-locked: '&c 需要 Minecraft [version]+'
+            <gray>點擊一個階段以拿起它，
+            再點擊要放置的位置。
+            右鍵點擊可切換
+            階段的啟用/停用。</gray>
+          invalid-length: '<red>長度必須是大於 0 的整數</red>'
+          length: '<gray>長度：</gray><aqua> [number]</aqua>'
+          length-cancelled: '<red>長度未變更</red>'
+          phase-name: '<green>[name]</green>'
+          pick-up: '<yellow>點擊以移動</yellow>'
+          put-back: '<yellow>點擊以放回</yellow>'
+          repeat: '<gray>最後一個階段結束後，計數將跳至 </gray><aqua>[number]</aqua>'
+          set-length: '<yellow>Shift + 左鍵點擊以設定長度</yellow>'
+          start: '<gray>起始：</gray><aqua> [number]</aqua>'
+          title: '<dark_green>階段順序</dark_green>'
+          toggle: '<yellow>右鍵點擊以切換</yellow>'
+          version-locked: '<red>需要 Minecraft [version]+</red>'
     count:
       description: 顯示方塊數量與所在階段
-      info: '&a你目前在 &a[name] &r階段，已破壞 &b[number] &r個方塊'
+      info: '<green>你目前在 [name] </green>階段，已破壞 <aqua>[number] </aqua>個方塊'
     info:
-      count: '&a 島位於 &b [names] &a 階段的 &b [number]&a 區塊。生命週期計數 &b [lifetime] &a。'
+      count: '<green>島位於 </green><aqua>[names] </aqua><green>階段的 </green><aqua>[number]</aqua><green> 區塊。生命週期計數 </green><aqua>[lifetime] </aqua><green>。</green>'
     phases:
       description: 顯示所有階段的列表
-      title: '&2 OneBlock階段'
-      name-syntax: '&a [name]'
-      description-syntax: '&b [number]塊'
+      title: '<dark_green>OneBlock階段</dark_green>'
+      name-syntax: '<green>[name]</green>'
+      description-syntax: '<aqua>[number]塊</aqua>'
     island:
       bossbar:
         description: 切換階段狀態列
-        status_on: '&b Bossbar&a 打開'
-        status_off: '&b Bossbar&c 關閉'
+        status_on: '<aqua>Bossbar</aqua><green> 打開</green>'
+        status_off: '<aqua>Bossbar</aqua><red> 關閉</red>'
       actionbar:
         description: 切換階段動作欄
-        status_on: "&b 動作欄已 &a 開啟"
-        status_off: "&b 動作欄已 &c 關閉"
+        status_on: "<aqua>動作欄已 </aqua><green>開啟</green>"
+        status_off: "<aqua>動作欄已 </aqua><red>關閉</red>"
       setcount:
         parameters: <計數>
         description: 將區塊計數設定為之前完成的值
-        set: '&a 計數設定為 [number]。'
-        too-high: '&c 你可以設定的最大值是 [number]！'
+        set: '<green>計數設定為 [number]。</green>'
+        too-high: '<red>你可以設定的最大值是 [number]！</red>'
     respawn-block:
       description: 在魔法塊消失的情況下重生
-      block-exist: '&a 方塊已存在，不需要重生，已為你標記位置。'
-      block-respawned: '&a 方塊已重生。'
+      block-exist: '<green>方塊已存在，不需要重生，已為你標記位置。</green>'
+      block-respawned: '<green>方塊已重生。</green>'
   phase:
-    insufficient-level: '&c 你的島嶼等級太低，無法繼續！必須是[number]。'
-    insufficient-funds: '&c 你的資金太低，無法繼續！至少需要 [number]。'
-    insufficient-bank-balance: '&c 島上銀行餘額太低，無法繼續！必須是[number]。'
-    insufficient-permission: '&c 在獲得 [name] 許可之前，你不能繼續操作！'
-    cooldown: '&c [number] 秒後即可進入下一階段！'
+    insufficient-level: '<red>你的島嶼等級太低，無法繼續！必須是[number]。</red>'
+    insufficient-funds: '<red>你的資金太低，無法繼續！至少需要 [number]。</red>'
+    insufficient-bank-balance: '<red>島上銀行餘額太低，無法繼續！必須是[number]。</red>'
+    insufficient-permission: '<red>在獲得 [name] 許可之前，你不能繼續操作！</red>'
+    cooldown: '<red>[number] 秒後即可進入下一階段！</red>'
   placeholders:
     infinite: 無窮
     my-island-phase-default: 未知
   gui:
     titles:
-      phases: '&0&l OneBlock 階段'
+      phases: '<black><bold>OneBlock 階段</bold></black>'
     buttons:
       previous:
-        name: '&f&l 上一頁'
-        description: '&7 切換到[number]頁'
+        name: '<white><bold>上一頁</bold></white>'
+        description: '<gray>切換到[number]頁</gray>'
       next:
-        name: '&f&l 下一頁'
-        description: '&7 切換到[number]頁'
+        name: '<white><bold>下一頁</bold></white>'
+        description: '<gray>切換到[number]頁</gray>'
       phase:
-        name: '&f&l [階段]'
+        name: '<white><bold>[階段]</bold></white>'
         description: |-
           [starting-block]
           [biome]
@@ -142,20 +142,20 @@ aoneblock:
           [economy]
           [level]
           [permission]
-        starting-block: '&7 在破壞 &e [number] 區塊後開始。'
-        biome: '&7 生態域：&e [biome]'
-        bank: '&7 需要銀行帳戶中有 &e $[number] &7。'
-        economy: '&7 需要玩家帳號中有 &e $[number] &7。'
-        level: '&7 需要 &e [number] &7 島嶼等級。'
-        permission: '&7 需要 `&e[permission]&7` 權限。'
-        blocks-prefix: '&7 階段塊 - '
-        blocks: '&e [name], '
+        starting-block: '<gray>在破壞 </gray><yellow>[number] 區塊後開始。</yellow>'
+        biome: '<gray>生態域：</gray><yellow> [biome]</yellow>'
+        bank: '<gray>需要銀行帳戶中有 </gray><yellow>$[number] </yellow><gray>。</gray>'
+        economy: '<gray>需要玩家帳號中有 </gray><yellow>$[number] </yellow><gray>。</gray>'
+        level: '<gray>需要 </gray><yellow>[number] </yellow><gray>島嶼等級。</gray>'
+        permission: '<gray>需要 `</gray><yellow>[permission]</yellow><gray>` 權限。</gray>'
+        blocks-prefix: '<gray>階段塊 - </gray>'
+        blocks: '<yellow>[name], </yellow>'
         wrap-at: '50'
     tips:
-      click-to-previous: '&e 點選&7 查看上一頁。'
-      click-to-next: '&e 點選&7 查看下一頁。'
-      click-to-change: '&e 點選 &7 進行更改。'
+      click-to-previous: '<yellow>點選</yellow><gray> 查看上一頁。</gray>'
+      click-to-next: '<yellow>點選</yellow><gray> 查看下一頁。</gray>'
+      click-to-change: '<yellow>點選 </yellow><gray>進行更改。</gray>'
   island:
     starting-hologram: |-
-      &a歡迎來到 AOneBlock
-      打破此區塊以開始(&E)
+      <green>歡迎來到 AOneBlock
+      打破此區塊以開始(</green><yellow>)</yellow>


### PR DESCRIPTION
BentoBox text is MiniMessage now. The old `&`-codes still parse, so nothing is broken today — but leaving the files in the legacy format is what makes formatting bugs possible: any code that builds a fragment and drops it into a translation has to guess which format the target line is written in, and guessing wrong renders colour codes as literal text. (That is exactly the bug this started as, in ChunkBlock's chunk map.)

All 18 locale files are now MiniMessage.

### How
Converted with BentoBox's own `Util.legacyToMiniMessage`, so each value now literally says what the runtime was already rendering — nothing hand-translated. Then tidied: a straight conversion closes and immediately reopens a tag wherever the old text repeated a colour code (every line of a multi-line flag description, every run split by a placeholder), so those `</aqua><aqua>` seams are closed up.

```yaml
# before
      description: |-
        &b Rank that can break the magic
        &b block if they can break blocks.

# after
      description: |-
        <aqua>Rank that can break the magic
        block if they can break blocks.</aqua>
```

### Verification
- Every one of the **1506 values** rendered before and after and compared **per character, with the style each character ends up with**. Nothing moved. (Comparing component trees was too strict — the tidy pass can nest `<bold>` inside `<green>` rather than the reverse, which is the same thing to a player.)
- Placeholder checker reports the **same 47 pre-existing issues** across the translations as before, none new.
- Comments, quoting style and numeric-looking values (`wrap-at: '50'`) survive the round trip.
- Full test suite green (570 tests).

### Left alone deliberately
Ten values in vi, tr, it, es, fr, uk and ja contain a **broken** colour code — `& c`, `& l`, `&un bloc` — that never rendered as colour. They still render as literal text, exactly as today. Fixing them changes what players see, so that is a translator's call, not this PR's.

### Related
Same migration in ChunkBlock: BentoBoxWorld/ChunkBlock#33, where the shared locale strings came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EZEwab2kL4i1FNnBYvSmp