### PR TITLE
fix: guard BossBarListener against null playerUUID from NPC/minion breaks

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/listeners/BossBarListener.java
+++ b/src/main/java/world/bentobox/aoneblock/listeners/BossBarListener.java
@@ -47,6 +47,9 @@ public class BossBarListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBreakBlockEvent(MagicBlockEvent e) {
+        if (e.getPlayerUUID() == null) {
+            return;
+        }
         // Update boss bar
         tryToShowBossBar(e.getPlayerUUID(), e.getIsland());
         tryToShowActionBar(e.getPlayerUUID(), e.getIsland());

--- a/src/test/java/world/bentobox/aoneblock/listeners/BossBarListenerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/listeners/BossBarListenerTest.java
@@ -211,4 +211,17 @@ public class BossBarListenerTest extends CommonTestSetup {
     void testBukkitToAdventureNullIsEmpty() {
         assertEquals(Component.empty(), BossBarListener.bukkitToAdventure(null));
     }
+
+    /**
+     * Test for https://github.com/BentoBoxWorld/AOneBlock/issues/557 - NPC/minion breaks
+     * fire MagicBlockEvent with a null playerUUID; the listener must not throw.
+     */
+    @Test
+    void testNullPlayerUUIDDoesNotThrow() {
+        when(island.isAllowed(addon.ONEBLOCK_BOSSBAR)).thenReturn(true);
+        when(island.isAllowed(addon.ONEBLOCK_ACTIONBAR)).thenReturn(true);
+        bbl.onBreakBlockEvent(new MagicBlockEvent(island, null, null, block, Material.STONE));
+        verify(mockPlayer, never()).sendActionBar(any(Component.class));
+        verify(bossBar, never()).addPlayer(any());
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #557 — JetsMinions (and other NPC/minion plugins) break the magic block via armor stand entities, firing `MagicBlockEvent` with a null `playerUUID`. `BossBarListener` passed this null UUID to `User.getInstance()`, which threw `IllegalArgumentException: UUID id cannot be null`.
- Added an early return in `BossBarListener.onBreakBlockEvent` when the player UUID is null — there's no player to display a bar to.
- Added a test covering the null UUID scenario.

## Test plan
- [x] Existing `BossBarListenerTest` passes (12/12)
- [x] New `testNullPlayerUUIDDoesNotThrow` verifies no exception and no bar/action bar display for null UUID events