### PR TITLE
fix: my_island placeholders fall back to team island for members

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/AOneBlockPlaceholders.java
+++ b/src/main/java/world/bentobox/aoneblock/AOneBlockPlaceholders.java
@@ -64,11 +64,11 @@ public class AOneBlockPlaceholders {
     }
 
     /**
-     * Get the user's owned island. Returns the island owned by the user, not a team
-     * island they may be visiting as a member. If the user owns more than one island,
-     * one is picked.
+     * Get the user's island. Prefers an island the user owns; if they own none,
+     * falls back to the team island they are a member of. If the user owns more
+     * than one island, one is picked.
      * @param user user
-     * @return island owned by the user, or empty if they own none
+     * @return island owned by the user, or their team island, or empty if neither exists
      */
     private Optional<Island> getUsersIsland(User user) {
         // Get the active island for the user
@@ -78,8 +78,14 @@ public class AOneBlockPlaceholders {
             return Optional.of(i);
         }
 
-        // Find an island the user actually owns (not just a team island they are visiting)
-        return addon.getIslands().getOwnedIslands(addon.getOverWorld(), user).stream().findFirst();
+        // Prefer an island the user actually owns (not just a team island they are a member of)
+        Optional<Island> owned = addon.getIslands().getOwnedIslands(addon.getOverWorld(), user).stream().findFirst();
+        if (owned.isPresent()) {
+            return owned;
+        }
+
+        // Fall back to the team island the user is a member of, if any
+        return Optional.ofNullable(i);
     }
 
     public String getPhaseBlocksNames(User user) {

--- a/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
+++ b/src/test/java/world/bentobox/aoneblock/PlaceholdersManagerTest.java
@@ -272,6 +272,27 @@ public class PlaceholdersManagerTest extends CommonTestSetup {
     }
 
     /**
+     * Test that my_island_* placeholders fall back to the team island for a team
+     * member who owns no island of their own. See issue #559.
+     */
+    @Test
+    void testTeamMemberWithoutOwnedIsland() {
+        when(user.getUniqueId()).thenReturn(uuid);
+        // The team island is owned by someone else
+        Island teamIsland = mock(Island.class);
+        when(teamIsland.getOwner()).thenReturn(UUID.randomUUID());
+        when(im.getIsland(world, user)).thenReturn(teamIsland);
+        // The user owns no island of their own
+        when(im.getOwnedIslands(world, user)).thenReturn(Set.of());
+        // Placeholders should show the team island's data, not the defaults
+        assertEquals("first", pm.getPhase(user));
+        assertEquals("1000", pm.getCount(user));
+        assertEquals("70%", pm.getPercentDone(user));
+        assertEquals("next_phase", pm.getNextPhase(user));
+        assertEquals("1000", pm.getLifetime(user));
+    }
+
+    /**
      * Test method for {@link world.bentobox.aoneblock.AOneBlockPlaceholders#getLifetimeByLocation(world.bentobox.bentobox.api.user.User)}.
      */
     @Test


### PR DESCRIPTION
## Summary
Fixes #559.

Since the `getUsersIsland()` rewrite that shipped in 1.26.0 (9ec2530), the `my_island_*` placeholders only resolved islands the player **owns**. A plain team member (who owns no island of their own) got the empty defaults — `0`, `0%`, `Unknown` — even though the placeholder docs say they work for the island owner or team member.

## Fix
`getUsersIsland()` now uses a preference order instead of a hard owner-only filter:
1. An island the player owns (preserves the 9ec2530 fix for players who own an island while also being a member of another team with `disallow-team-member-islands: false`).
2. Otherwise, the team island the player is a member of.
3. Otherwise, empty (existing default values).

## Testing
- New regression test `testTeamMemberWithoutOwnedIsland` covering the #559 scenario.
- Full test suite passes (575 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtmXKNJ5fSZ9sEumeFDEBc