### PR TITLE
docs: clarify which deaths settings affect Level 2.29.0 island levels

### DIFF
--- a/src/main/java/world/bentobox/aoneblock/Settings.java
+++ b/src/main/java/world/bentobox/aoneblock/Settings.java
@@ -616,18 +616,24 @@ public class Settings implements WorldSettings {
 
     // Deaths
     @ConfigComment("Whether deaths are counted or not.")
+    @ConfigComment("If false, BentoBox does not count deaths and the Level addon does not record deaths against islands.")
     @ConfigEntry(path = "island.deaths.counted")
     private boolean deathsCounted = true;
 
     @ConfigComment("Maximum number of deaths to count. The death count can be used by add-ons.")
+    @ConfigComment("Since Level 2.29.0 this also caps how many deaths each member can contribute to an island's death penalty.")
     @ConfigEntry(path = "island.deaths.max")
     private int deathsMax = 10;
 
-    @ConfigComment("When a player joins a team, reset their death count")
+    @ConfigComment("When a player joins a team, reset their death count.")
+    @ConfigComment("This only affects BentoBox's own per-player death count, used by the %aoneblock_deaths% placeholder.")
+    @ConfigComment("Since Level 2.29.0, island levels use per-island death tracking and are not affected by this setting.")
     @ConfigEntry(path = "island.deaths.team-join-reset")
     private boolean teamJoinDeathReset = true;
 
-    @ConfigComment("Reset player death count when they start a new island or reset an island")
+    @ConfigComment("Reset player death count when they start a new island or reset an island.")
+    @ConfigComment("This only affects BentoBox's own per-player death count.")
+    @ConfigComment("Since Level 2.29.0 the Level addon clears an island's own death record automatically when it is reset or deleted.")
     @ConfigEntry(path = "island.deaths.reset-on-new-island") // , since = "1.6.0")
     private boolean deathsResetOnNewIsland = true;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -560,12 +560,18 @@ island:
       require-confirmation: true
   deaths:
     # Whether deaths are counted or not.
+    # If false, BentoBox does not count deaths and the Level addon does not record deaths against islands.
     counted: true
     # Maximum number of deaths to count. The death count can be used by add-ons.
+    # Since Level 2.29.0 this also caps how many deaths each member can contribute to an island's death penalty.
     max: 10
-    # When a player joins a team, reset their death count
+    # When a player joins a team, reset their death count.
+    # This only affects BentoBox's own per-player death count, used by the %aoneblock_deaths% placeholder.
+    # Since Level 2.29.0, island levels use per-island death tracking and are not affected by this setting.
     team-join-reset: true
-    # Reset player death count when they start a new island or reset an island
+    # Reset player death count when they start a new island or reset an island.
+    # This only affects BentoBox's own per-player death count.
+    # Since Level 2.29.0 the Level addon clears an island's own death record automatically when it is reset or deleted.
     reset-on-new-island: true
 protection:
   # Geo restrict mobs.


### PR DESCRIPTION
Level 2.29.0 (BentoBoxWorld/Level#459) moves death tracking for island levels out of BentoBox's per-player, per-world death counter and into Level itself, per island. That changes what the four `deaths` settings in this game mode's config actually do:

| Setting | Effect after Level 2.29.0 |
|---|---|
| `counted` | Still the master switch. If false, Level records no deaths. |
| `max` | Still applies, but now caps each member's deaths per island rather than per world. |
| `team-join-reset` | Only affects BentoBox's own counter and the `%[gamemode]_deaths%` placeholder. No effect on levels. |
| `reset-on-new-*` | Only affects BentoBox's own counter. Level clears an island's death record itself on reset/delete. |

This PR updates the `@ConfigComment` text in `Settings.java` and the matching comments in `config.yml` so admins can see which settings still matter for levels. Comment-only change, no keys or defaults altered, so existing configs are unaffected. Also fixes the "reset and island" typo where present.

Same change is being opened across all game modes with a deaths block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxX9oscerhv1nsozPbT5aX
